### PR TITLE
Upstall Java

### DIFF
--- a/.config/fish/functions/fd.fish
+++ b/.config/fish/functions/fd.fish
@@ -1,11 +1,11 @@
 # Delete a function
 function fd --argument function_name
-	if not functions --query $function_name
+    set -l file ~/.config/fish/functions/$function_name.fish
+
+    if not functions --query $function_name; and not test -e $file
         echo "Function "$function_name" does not exist."
         return 1
     end
-
-    set -l file ~/.config/fish/functions/$function_name.fish
 
     functions --erase $function_name
     # Delete file if it exists

--- a/.config/fish/functions/fd.fish
+++ b/.config/fish/functions/fd.fish
@@ -5,6 +5,10 @@ function fd --argument function_name
         return 1
     end
 
+    set -l file ~/.config/fish/functions/$function_name.fish
+
     functions --erase $function_name
-        and echo "Function "$function_name" deleted."
+    # Delete file if it exists
+    and not test -e $file; or rm -f $file
+    and echo "Function "$function_name" deleted."
 end

--- a/.config/fish/functions/fe.fish
+++ b/.config/fish/functions/fe.fish
@@ -1,8 +1,10 @@
 # Edit a function.
 function fe --argument-names function_name
-    if not functions --query $function_name
-        yn $function_name" doesn't exist. Create?"
-            and fn $function_name
+    set -l file ~/.config/fish/functions/$function_name.fish
+
+    if not functions --query $function_name; and not test -e $file
+        yn "Function "$function_name" does not exist. Create?"
+        and fn $function_name
         return
     end
 

--- a/.config/fish/functions/fe.fish
+++ b/.config/fish/functions/fe.fish
@@ -10,7 +10,15 @@ function fe --argument-names function_name
 
     toggle_wait on
 
-    funced $function_name
+    if test -e $file
+        # Edit an autoloaded function
+        edit $file
+        and reload $function_name
+    else
+        # Edit a builtin function, save to autoload
+        funced $function_name
+        and funcsave $function_name
+    end
 
     toggle_wait off
 end

--- a/.config/fish/functions/fn.fish
+++ b/.config/fish/functions/fn.fish
@@ -1,12 +1,12 @@
 # Create a new function.
 function fn --argument function_name
-    if functions --query $function_name
-        yn $function_name" already exists. Edit?"
+    set -l file ~/.config/fish/functions/$function_name.fish
+
+    if functions --query $function_name; and not test -e $file
+        yn "Function "$function_name" already exists. Edit?"
         and fe $function_name
         return
     end
-
-    set -l file ~/.config/fish/functions/$function_name.fish
 
     # Function template
     echo "# $function_name

--- a/.config/fish/functions/fn.fish
+++ b/.config/fish/functions/fn.fish
@@ -24,7 +24,8 @@ end"\
 >$file
 
     editw $file
-    fish_indent $file
+    fish_indent --write $file
+    reload $function_name
 
     echo $function_name function created.
 end

--- a/.config/fish/functions/fn.fish
+++ b/.config/fish/functions/fn.fish
@@ -10,18 +10,18 @@ function fn --argument function_name
 
     # Function template
     echo "# $function_name
- function $function_name --argument-names arg1
-     if test -z \$arg1
-         echo \"Usage: $function_name arg1\"
-         return 1
-     end
-     switch \$arg1
-         case on ON On
-         case off OFF Off
-         case '*'
-     end
- end"\
- >$file
+function $function_name --argument-names arg1
+    if test -z \$arg1
+        echo \"Usage: $function_name arg1\"
+        return 1
+    end
+    switch \$arg1
+        case on ON On
+        case off OFF Off
+        case '*'
+    end
+end"\
+>$file
 
     editw $file
     fish_indent $file

--- a/.config/fish/functions/fq.fish
+++ b/.config/fish/functions/fq.fish
@@ -1,4 +1,7 @@
 # Check for existence of a function.
 function fq --argument-names function_name
+    set -l file ~/.config/fish/functions/$function_name.fish
+
     functions --query $function_name
+    or test -e $file
 end

--- a/.config/fish/functions/func.fish
+++ b/.config/fish/functions/func.fish
@@ -4,6 +4,9 @@ function func \
     if test -z "$name"
         echo "Usage: func name"
         return 1
+    else if not functions --query $name
+        echo "$name does not exist"
+        return 2
     end
 
     functions $name | fish_indent --ansi

--- a/.config/fish/functions/jv.fish
+++ b/.config/fish/functions/jv.fish
@@ -1,9 +1,10 @@
 # Displays the Java version number.
 function jv
-    # Example output:
+	# Example output (goes to stderr!):
     # java version "1.8.0_131"
     # Java(TM) SE Runtime Environment (build 1.8.0_131-b11)
     # Java HotSpot(TM) 64-Bit Server VM (build 25.131-b11, mixed mode)
-    set -l output (java -version)[1]
-    echo $output
+    set -l output (java -version 2>&1)
+    set -l version (string replace --all '"' '' (string split ' ' $output[1])[-1])
+    echo $version
 end

--- a/.config/fish/functions/jv.fish
+++ b/.config/fish/functions/jv.fish
@@ -1,0 +1,9 @@
+# Displays the Java version number.
+function jv
+    # Example output:
+    # java version "1.8.0_131"
+    # Java(TM) SE Runtime Environment (build 1.8.0_131-b11)
+    # Java HotSpot(TM) 64-Bit Server VM (build 25.131-b11, mixed mode)
+    set -l output (java -version)[1]
+    echo $output
+end

--- a/.config/fish/functions/pkgfind.fish
+++ b/.config/fish/functions/pkgfind.fish
@@ -5,5 +5,5 @@ function pkgfind --argument-names filter
         return 1
     end
 
-    pkgutil --packages | grep $filter
+    pkgutil --packages | grep -i $filter
 end

--- a/.config/fish/functions/reload.fish
+++ b/.config/fish/functions/reload.fish
@@ -1,11 +1,13 @@
 # Reloads fish configuration or a single autoloaded function.
 function reload --argument-names function_name
+    set -l file ~/.config/fish/functions/$function_name.fish
+
     if test -z $function_name
         source ~/.config/fish/config.fish
         return
-    else if functions --query $function_name
-        source ~/.config/fish/functions/$function_name.fish
-        if not test $status -ne 0
+    else if test -e $file
+        source $file
+        if test $status -ne 0
             return $status
         end
         func $function_name

--- a/.config/fish/functions/setjdk.fish
+++ b/.config/fish/functions/setjdk.fish
@@ -1,4 +1,9 @@
 # Update JAVA_HOME to point to the given JDK version.
-function setjdk
-    set -x JAVA_HOME (/usr/libexec/java_home --version $argv)
+function setjdk --argument-names version
+    if test -z $version
+        echo "Usage: setjdk 1.8"
+        return 1
+    end
+
+    set --export JAVA_HOME (/usr/libexec/java_home --version $version)
 end

--- a/.config/fish/functions/setjdk.fish
+++ b/.config/fish/functions/setjdk.fish
@@ -1,7 +1,7 @@
 # Update JAVA_HOME to point to the given JDK version.
 function setjdk --argument-names version
     if test -z $version
-        echo "Usage: setjdk 1.8"
+        echo "Usage: setjdk 1.8 (or) setjdk 1.8.0_111"
         return 1
     end
 

--- a/.config/fish/functions/showjdks.fish
+++ b/.config/fish/functions/showjdks.fish
@@ -1,4 +1,4 @@
 # Show all installed JDKs.
 function showjdks
-    /usr/libexec/java_home -V $argv
+    /usr/libexec/java_home --verbose $argv
 end

--- a/.config/fish/functions/⏫__upstall.fish
+++ b/.config/fish/functions/⏫__upstall.fish
@@ -9,7 +9,7 @@ function ⏫__upstall
     date_iso8601 >$last_ran_file
 
     if contains -- --nothing $argv
-        set argv $argv --no-ruby --no-xcode --no-brew --no-cask --no-fisherman --no-pip --no-npm --no-textmate --no-macos
+        set argv $argv --no-ruby --no-xcode --no-brew --no-cask --no-fisherman --no-pip --no-npm --no-textmate --no-java --no-macos
     end
 
     ⬆️__upmodule 🗄__gitconfig
@@ -21,5 +21,6 @@ function ⏫__upstall
     ⬆️__upmodule 🐍__pip         "🐍  PIP"       --no-pip        --nopy $argv
     ⬆️__upmodule 🕸__npm         "🕸  NPM"       --no-npm        --nojs $argv
     ⬆️__upmodule 📝__textmate    "📝  TextMate"  --no-textmate   --notm $argv
+    ⬆️__upmodule ☕️__java        "☕️  Java"      --no-java       --nojv $argv
     ⬆️__upmodule 🖥__macos       "🖥  macOS"     --no-macos      --noos $argv
 end

--- a/.config/fish/functions/☕️__java.fish
+++ b/.config/fish/functions/☕️__java.fish
@@ -25,11 +25,22 @@ function ☕️__java
     curl_download --cookie oraclelicense=accept-securebackup-cookie $download_url
 
     # Mount the .dmg
-    hdiutil attach $dmg_file
+    # -nobrowse          render any volumes invisible in applications such as the macOS Finder.
+    set -l output (hdiutil attach $dmg_file)
+
+    # Mount pout is the first column of the last line of output from hdiutil
+    # Example:
+    # expected   CRC32 $09D78DD5
+    # /dev/disk2              GUID_partition_scheme
+    # /dev/disk2s1            Apple_HFS                          /Volumes/JDK 8 Update 131
+    set -l mount_point (echo $output[-1] | cut -f 1 -d ' ' -)
     ls -o /Volumes/JDK*/JDK*.pkg
 
     # Run the install package
     sudo installer -target / -pkg /Volumes/JDK*/JDK*.pkg
+
+    # Unmount the install volume
+    hdiutil detach $mount_point
 
     # Switch active JDK
     showjdks

--- a/.config/fish/functions/☕️__java.fish
+++ b/.config/fish/functions/☕️__java.fish
@@ -3,9 +3,9 @@
 # https://support.apple.com/kb/dl1572?locale=en_US
 #
 # Redirects
-# 1.  https://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-macosx-x64.dmg
-# 2.  https://edelivery.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-macosx-x64.dmg
-# 3.  http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-macosx-x64.dmg?AuthParam=1494782728_c178605a1daa320f359ffa3d47b0cc2d
+# 1. https://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-macosx-x64.dmg
+# 2. https://edelivery.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-macosx-x64.dmg
+# 3. http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-macosx-x64.dmg?AuthParam=1494782728_c178605a1daa320f359ffa3d47b0cc2d
 #
 # Cookie set by JavaScript after clicking the "Agree" radio button
 # - oraclelicense	accept-securebackup-cookie	.oracle.com	/	5/14/2017, 11:56:38 AM	39 B

--- a/.config/fish/functions/☕️__java.fish
+++ b/.config/fish/functions/☕️__java.fish
@@ -16,6 +16,14 @@ function ☕️__java
     echo "☕️  Java"
     echo
 
+    set -l version 1.8.0_131
+
+    # Check to see if update is necessary
+    if test $version = (jv)
+        showjdks
+        return
+    end
+
     set -l download_url http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-macosx-x64.dmg
     set -l dmg_file (basename $download_url)
 

--- a/.config/fish/functions/☕️__java.fish
+++ b/.config/fish/functions/☕️__java.fish
@@ -26,6 +26,18 @@ function ☕️__java
 
     # Mount the .dmg
     hdiutil attach $dmg_file
+    ls -o /Volumes/JDK*/JDK*.pkg
+
+    # Run the install package
+    sudo installer -target / -pkg /Volumes/JDK*/JDK*.pkg
+
+    # Switch active JDK
+    showjdks
+    setjdk 1.8
+
+    # Show version info
+    whichjdk
+    java -version
 
     popd
 end

--- a/.config/fish/functions/☕️__java.fish
+++ b/.config/fish/functions/☕️__java.fish
@@ -1,0 +1,31 @@
+# Installs and updates the Java SDK.
+# http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html
+# https://support.apple.com/kb/dl1572?locale=en_US
+#
+# Redirects
+# 1.  https://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-macosx-x64.dmg
+# 2.  https://edelivery.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-macosx-x64.dmg
+# 3.  http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-macosx-x64.dmg?AuthParam=1494782728_c178605a1daa320f359ffa3d47b0cc2d
+#
+# Cookie set by JavaScript after clicking the "Agree" radio button
+# - oraclelicense	accept-securebackup-cookie	.oracle.com	/	5/14/2017, 11:56:38 AM	39 B
+#
+# Sequencing
+# - After: brew (has newer curl)
+function ☕️__java
+    echo "☕️  Java"
+    echo
+
+    set -l download_url http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-macosx-x64.dmg
+    set -l dmg_file (basename $download_url)
+
+    pushd ~/Downloads
+
+    # Download
+    curl_download --cookie oraclelicense=accept-securebackup-cookie $download_url
+
+    # Mount the .dmg
+    hdiutil attach $dmg_file
+
+    popd
+end


### PR DESCRIPTION
Downloads macOS .dmg file from http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html

Download URL example: https://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-macosx-x64.dmg
- Requires that `oraclelicense` cookie be set to `accept-securebackup-cookie`
- Must follow 2 redirects which adds `AuthParam` query string parameter

Also fixed some issues with function manipulation functions.