### PR TITLE
chore(mise): bump mint to 4.2.392

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -15,7 +15,7 @@
 "npm:@vtsls/language-server" = "0.3.0"
 "npm:ccusage" = "18.0.8"
 "npm:claudekit" = "0.9.4"
-"npm:mint" = "4.2.391"
+"npm:mint" = "4.2.392"
 "npm:prettier" = "3.8.1"
 "npm:vscode-langservers-extracted" = "4.10.0"
 "npm:yarn" = "1.22.22"


### PR DESCRIPTION
One-line bump in .config/mise/config.toml.