### PR TITLE
chore(mise): bump awscli to 2.34.0

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -23,7 +23,7 @@
 "pipx:python-lsp-server" = "1.14.0"
 act = "0.2.84"
 actionlint = "1.7.11"
-awscli = "2.33.3"
+awscli = "2.34.0"
 bat = "0.26.1"
 bats = "1.13.0"
 bazelisk = "1.28.1"


### PR DESCRIPTION
One-line bump in .config/mise/config.toml.