### PR TITLE
Allow tracking gt/settings/config.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -812,7 +812,10 @@ fvm/
 games/
 go/
 gradlew.bat
-gt/
+gt/*
+!gt/settings/
+gt/settings/*
+!gt/settings/config.json
 heapdump.*.phd
 iCloud Drive (Archive)/
 javacore.*.txt


### PR DESCRIPTION
## Summary
- Replace blanket `gt/` gitignore with `gt/*` plus negation overrides
- Allows `gt/settings/config.json` (Gas Town agent/cost tier config) to be tracked
- After merging, run `git add -f ~/gt/settings/config.json` from the home dir to start tracking it

## Changes to .gitignore
```
gt/*
!gt/settings/
gt/settings/*
!gt/settings/config.json
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)