### PR TITLE
Add agent-claude wrapper for scoped GitHub tokens

### DIFF
--- a/scripts/agent-claude.sh
+++ b/scripts/agent-claude.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# agent-claude.sh - Wrapper that runs claude with a scoped-down GitHub token
+#
+# Used by Gas Town agent sessions to limit gh CLI permissions.
+# The token file must exist and contain a fine-grained PAT with:
+#   - Contents: Read & Write (push topic branches)
+#   - Pull requests: Read & Write (create/update PRs, comment, draft toggle)
+#   - Actions: Read & Write (re-run failed CI jobs)
+#   - Metadata: Read (auto-granted)
+#
+# Token file: ~/.config/gastown/agent-gh-token
+# Create at: https://github.com/settings/personal-access-tokens/new
+
+set -euo pipefail
+
+TOKEN_FILE="${HOME}/.config/gastown/agent-gh-token"
+
+if [[ -f "$TOKEN_FILE" ]]; then
+    export GH_TOKEN
+    GH_TOKEN="$(cat "$TOKEN_FILE")"
+else
+    echo "WARNING: agent-gh-token not found at $TOKEN_FILE" >&2
+    echo "Agents will use default gh auth (full permissions)" >&2
+fi
+
+exec claude "$@"


### PR DESCRIPTION
## Summary
- Add `scripts/agent-claude.sh` wrapper that sets `GH_TOKEN` before launching claude
- Token is read from `~/.config/gastown/agent-gh-token` (outside repo, `chmod 600`)
- Falls back to default auth with a warning if token file is missing

## Setup after merge
1. Create a [fine-grained PAT](https://github.com/settings/personal-access-tokens/new) with:
   - **Contents**: Read & Write
   - **Pull requests**: Read & Write
   - **Actions**: Read & Write
   - Repository access: select specific repos
2. Save token: `echo "github_pat_..." > ~/.config/gastown/agent-gh-token && chmod 600 ~/.config/gastown/agent-gh-token`
3. Update gastown role configs to use `~/scripts/agent-claude.sh` instead of `claude`

## What agents CAN do
- Push topic branches
- Create/update/comment on PRs
- Toggle draft/ready status
- Re-run failed CI jobs

## What agents CANNOT do
- Merge PRs (branch protection)
- Push to default branch (branch protection)
- Access secrets, admin settings, org permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)