### PR TITLE
chore: replace specific .claude.json.tmp entries with glob pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,9 +67,7 @@
 .claude.json
 .claude.json.backup
 .claude.json.backup.*
-.claude.json.tmp.60106.1772720677979
-.claude.json.tmp.8325.1773042876273
-.claude.json.tmp.90442.1773143362931
+.claude.json.tmp.*
 .claude/.credentials.json
 .claude/commands/
 .claude/debug/


### PR DESCRIPTION
## Summary
- Replaces three hardcoded `.claude.json.tmp.<pid>.<timestamp>` entries in `.gitignore` with a single `.claude.json.tmp.*` glob pattern
- Prevents needing to add new entries each time Claude Code creates a temp file with a different PID/timestamp

## Test plan
- [x] Verify `.gitignore` correctly ignores all `.claude.json.tmp.*` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)