### PR TITLE
fix: sunday fixes - mise syntax and zed claude-acp migration

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -9,7 +9,7 @@
 "github:harness/harness-cli" = "1.3.11"
 "github:schpet/linear-cli" = "1.11.1"
 "github:steveyegge/gastown" = "0.12.1"
-"go:github.com/steveyegge/beads/cmd/bd" = "0.61.0
+"go:github.com/steveyegge/beads/cmd/bd" = "0.61.0"
 "go:golang.org/x/tools/gopls" = "0.21.1"
 "npm:@googleworkspace/cli" = "0.16.0"
 "npm:@linear/cli" = "0.0.5"

--- a/.config/zed/settings.json
+++ b/.config/zed/settings.json
@@ -18,7 +18,8 @@
     }
   },
   "agent_servers": {
-    "claude": {
+    "claude-acp": {
+      "type": "registry",
       "default_mode": "acceptEdits"
     }
   },


### PR DESCRIPTION
## Summary
- Fix syntax error in mise config.toml
- Migrate Zed claude agent server to claude-acp

## Test plan
- [x] Verify mise config loads without errors
- [x] Verify Zed claude-acp agent server works

🤖 Generated with [Claude Code](https://claude.com/claude-code)