### PR TITLE
feat: enable gopls, wasteland marketplace, and gt path fixes

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,6 @@
 {
   "enabledPlugins": {
+    "gopls-lsp@claude-plugins-official": true,
     "kotlin-lsp@claude-plugins-official": true,
     "rust-analyzer-lsp@claude-plugins-official": true,
     "wasteland@gastownhall-marketplace": true

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,12 +1,21 @@
 {
   "enabledPlugins": {
     "kotlin-lsp@claude-plugins-official": true,
-    "rust-analyzer-lsp@claude-plugins-official": true
+    "rust-analyzer-lsp@claude-plugins-official": true,
+    "wasteland@gastownhall-marketplace": true
   },
   "env": {
     "BASH_DEFAULT_TIMEOUT_MS": "300000",
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "MAX_MCP_OUTPUT_TOKENS": "25000"
+  },
+  "extraKnownMarketplaces": {
+    "gastownhall-marketplace": {
+      "source": {
+        "repo": "gastownhall/marketplace",
+        "source": "github"
+      }
+    }
   },
   "hooks": {
     "PermissionRequest": [

--- a/.codexbar/config.json
+++ b/.codexbar/config.json
@@ -6,11 +6,11 @@
       "id": "claude"
     },
     {
-      "enabled": true,
+      "enabled": false,
       "id": "codex"
     },
     {
-      "enabled": true,
+      "enabled": false,
       "id": "gemini"
     },
     {

--- a/.config/zsh/functions/gt
+++ b/.config/zsh/functions/gt
@@ -1,9 +1,9 @@
 #!/usr/bin/env zsh
 
-# gt - Run gastown commands from ~/gt directory
+# gt - Run gastown commands via ~/.local/bin/gt
 # In Claude Code sessions, pass through to the binary on PATH
 [[ -n "$CLAUDE_CODE" ]] && {
     command gt "$@"
     return
 }
-(cd ~/gt && command gt "$@")
+(cd ~/gt && ~/.local/bin/gt "$@")

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@
 .anka/
 .ansible/
 .antigen/
+.antigravity/
 .anyconnect
 .asdf/
 .aspnet/
@@ -442,6 +443,7 @@ Library/Application Support/AYA/
 Library/Application Support/AddressBook/
 Library/Application Support/Alfred/
 Library/Application Support/Animoji/
+Library/Application Support/Antigravity/
 Library/Application Support/App Store/
 Library/Application Support/Arc/
 Library/Application Support/AskPermission/


### PR DESCRIPTION
## Summary
- Enable gopls LSP plugin for Go development support
- Add wasteland marketplace plugin and Gas Town Hall marketplace source
- Point `gt` zsh function to `~/.local/bin/gt`
- Ignore `.antigravity/` and `Library/Application Support/Antigravity/` directories

## Test plan
- [ ] Verify gopls LSP works in Claude Code sessions
- [ ] Verify wasteland marketplace plugin loads
- [ ] Verify `gt` function works in both Claude Code and normal shell sessions
- [ ] Confirm ignored directories don't appear in git status

🤖 Generated with [Claude Code](https://claude.com/claude-code)