### PR TITLE
feat(ci): add GitHub Actions lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,64 @@
+name: lint
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".config/fish/**"
+      - ".config/nushell/**"
+      - ".config/zsh/functions/**"
+      - ".config/mise/config.toml"
+      - ".gitignore"
+      - "bin/**"
+      - "justfile"
+      - "scripts/**"
+      - ".github/workflows/lint.yml"
+  pull_request:
+    paths:
+      - ".config/fish/**"
+      - ".config/nushell/**"
+      - ".config/zsh/functions/**"
+      - ".config/mise/config.toml"
+      - ".gitignore"
+      - "bin/**"
+      - "justfile"
+      - "scripts/**"
+      - ".github/workflows/lint.yml"
+  schedule:
+    # Weekly Monday 06:00 UTC — catch drift from tool updates
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    env:
+      # Repo root IS the home directory; remap HOME so ~ resolves to checkout
+      HOME: ${{ github.workspace }}
+      MISE_PIN: "1"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install mise
+        uses: jdx/mise-action@v2
+        with:
+          install: false
+
+      - name: Install mise-managed tools
+        run: mise install just shellcheck ruff
+
+      - name: Install fish
+        run: sudo apt-get update && sudo apt-get install -y fish
+
+      - name: Install nushell
+        run: |
+          nu_version="0.104.0"
+          curl -sSL "https://github.com/nushell/nushell/releases/download/${nu_version}/nu-${nu_version}-x86_64-unknown-linux-gnu.tar.gz" \
+            | sudo tar -xz --strip-components=1 -C /usr/local/bin "nu-${nu_version}-x86_64-unknown-linux-gnu/nu"
+
+      - name: Lint
+        run: |
+          eval "$(mise activate bash)"
+          just lint


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/lint.yml` that runs `just lint` on push to main, PRs, and a weekly schedule (Mondays 06:00 UTC)
- Uses `mise` for tool installation (shellcheck, ruff, just) to match local dev toolchain
- Sets `HOME=$GITHUB_WORKSPACE` so `~` paths in the justfile resolve to the checkout directory
- Installs fish (apt) and nushell (binary download) for syntax validation steps

## Design decisions
- **Path filters** — only triggers on shell scripts, configs, and workflow changes
- **Weekly schedule** — catches drift from tool updates; GitHub emails on failure by default
- **Minimal mise install** — only installs 3 tools needed for lint, not all 70+

## Test plan
- [x] Verify workflow triggers on PR creation
- [x] Confirm `just lint` passes in CI with `HOME` override
- [x] Validate fish/nushell install steps succeed on ubuntu-latest
- [ ] Verify weekly schedule triggers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)