### PR TITLE
chore: add lua-lsp plugin and bump vfox-gcloud

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,6 +3,7 @@
     "clangd-lsp@claude-plugins-official": true,
     "gopls-lsp@claude-plugins-official": true,
     "kotlin-lsp@claude-plugins-official": true,
+    "lua-lsp@claude-plugins-official": true,
     "ruby-lsp@claude-plugins-official": true,
     "rust-analyzer-lsp@claude-plugins-official": true,
     "wasteland@gastownhall-marketplace": true

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -23,7 +23,7 @@
 "npm:yarn" = "1.22.22"
 "pipx:pyright" = "1.1.408"
 "pipx:python-lsp-server" = "1.14.0"
-"vfox:mise-plugins/vfox-gcloud" = "561.0.0"
+"vfox:mise-plugins/vfox-gcloud" = "562.0.0"
 act = "0.2.85"
 actionlint = "1.7.11"
 awscli = { version = "2.34.16", symlink_bins = "true" }


### PR DESCRIPTION
## Summary
- Add lua-lsp plugin to Claude settings
- Bump vfox:mise-plugins/vfox-gcloud 561.0.0 → 562.0.0

## Test plan
- [ ] Verify mise tool versions install correctly
- [ ] Verify Claude settings load without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)