### PR TITLE
feat: Xcode tooling, mise upgrade, renovate config, PR body format

### DIFF
--- a/.claude/commands/plan/linear.md
+++ b/.claude/commands/plan/linear.md
@@ -290,9 +290,9 @@ gh pr create --draft \
   --assignee phatblat \
   --label "D-skip-changelog,<K-label>,<A-label>,<additional-labels>" \
   --body "$(cat <<'EOF'
-## Summary
-
 Resolves [DEVX-NNN](https://linear.app/ditto/issue/DEVX-NNN)
+
+## Summary
 
 <1-3 bullet points describing the changes>
 

--- a/.claude/skills/commit-message/SKILL.md
+++ b/.claude/skills/commit-message/SKILL.md
@@ -222,6 +222,9 @@ If user wants a PR:
 
 ```bash
 gh pr create --title "<title>" --body "$(cat <<'EOF'
+Resolves #[number] (if applicable)
+Related: #[PR-number] (if applicable)
+
 ## Summary
 - [bullet points of changes]
 
@@ -239,15 +242,18 @@ EOF
 - Use the body for details, not the title
 
 ### PR Body Template
+
+**IMPORTANT:** Ticket references and links to related PRs MUST appear above the first heading, on their own lines, so they are immediately visible.
+
 ```markdown
+Closes #[number] (if applicable)
+Related: #[PR-number] (if applicable)
+
 ## Summary
 [1-3 bullet points describing what changed and why]
 
 ## Test Plan
 - [ ] [Steps to verify the changes work]
-
-## Related Issues
-Closes #[number] (if applicable)
 ```
 
 **Always confirm PR title and body before creating.**

--- a/.config/zsh/functions/codesign_verify
+++ b/.config/zsh/functions/codesign_verify
@@ -1,0 +1,4 @@
+#!/usr/bin/env zsh
+
+# codesign_verify - Verify the codesign of a bundle
+codesign --verify -vvvv -R='anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.1] exists and (certificate leaf[field.1.2.840.113635.100.6.1.2] exists or certificate leaf[field.1.2.840.113635.100.6.1.4] exists)' "$@"

--- a/.config/zsh/functions/dsyminfo
+++ b/.config/zsh/functions/dsyminfo
@@ -1,0 +1,11 @@
+#!/usr/bin/env zsh
+
+# dsyminfo - Displays information for a Dwarf symbol file
+local file=$1
+
+if [[ -z "$file" ]]; then
+    echo "Usage: dsyminfo path/to/dsym"
+    return 1
+fi
+
+dwarfdump -u "$file" "${@:2}"

--- a/.config/zsh/functions/finddsym
+++ b/.config/zsh/functions/finddsym
@@ -1,0 +1,11 @@
+#!/usr/bin/env zsh
+
+# finddsym - Locates a dSYM file with the given UUID
+local uuid=$1
+
+if [[ -z "$uuid" ]]; then
+    echo "Usage: finddsym uuid"
+    return 1
+fi
+
+mdfind "com_apple_xcode_dsym_uuids == <$uuid>"

--- a/.config/zsh/functions/iphones
+++ b/.config/zsh/functions/iphones
@@ -1,0 +1,4 @@
+#!/usr/bin/env zsh
+
+# iphones - Show connected iOS devices
+system_profiler SPUSBDataType | sed -n -E -e '/(iPhone|iPad)/,/Serial/s/ *Serial Number: *(.+)/\1/p'

--- a/.config/zsh/functions/profile_id
+++ b/.config/zsh/functions/profile_id
@@ -1,0 +1,13 @@
+#!/usr/bin/env zsh
+
+# profile_id - Extracts the UUID from a .mobileprovision profile
+local profile=$1
+
+if [[ -z "$profile" ]]; then
+    echo "Usage: profile_id AppProfile.mobileprovision"
+    return 1
+fi
+
+grep -a -A 2 UUID "$profile" \
+    | grep string \
+    | sed -e 's/<string>//' -e 's/<\/string>//' -e 's/[ 	]//'

--- a/.config/zsh/functions/provisioning_uuid
+++ b/.config/zsh/functions/provisioning_uuid
@@ -1,0 +1,15 @@
+#!/usr/bin/env zsh
+
+# provisioning_uuid - Prints the UUID from a provisioning profile
+local profile_path=$1
+
+if [[ -z "$profile_path" ]]; then
+    echo "Usage: provisioning_uuid path/to/profile.mobileprovision"
+    return 1
+fi
+
+provisioning_print "$profile_path" \
+    | grep UUID -A 1 \
+    | tail -n 1 \
+    | cut -d ">" -f 2 \
+    | cut -d "<" -f 1

--- a/.config/zsh/functions/signing_cert_details
+++ b/.config/zsh/functions/signing_cert_details
@@ -1,0 +1,15 @@
+#!/usr/bin/env zsh
+
+# signing_cert_details - Prints signing certificate details
+local cert_name=$1
+
+if [[ -z "$cert_name" ]]; then
+    echo "Usage: signing_cert_details \"iOS Dev: Me\"" >&2
+    echo "Use the list_codesign_identities function to find the certificate name." >&2
+    return 1
+fi
+
+security find-certificate \
+    -c "$cert_name" \
+    -p \
+    | openssl x509 -text

--- a/.config/zsh/functions/simclean
+++ b/.config/zsh/functions/simclean
@@ -1,0 +1,4 @@
+#!/usr/bin/env zsh
+
+# simclean - Deletes all unavailable simulators
+xcrun simctl delete unavailable

--- a/.config/zsh/functions/version
+++ b/.config/zsh/functions/version
@@ -1,0 +1,47 @@
+#!/usr/bin/env zsh
+
+# version - Manage version numbers for an Xcode project
+local action=${1:-'*'}
+local market_version=$2
+local build_version=$3
+
+case "$action" in
+    build)
+        version_build
+        ;;
+    market)
+        version_market
+        ;;
+    set)
+        if [[ -z "$market_version" ]]; then
+            echo "Usage: version set 1.1 123456"
+            return 1
+        fi
+
+        agvtool new-marketing-version "$market_version" > /dev/null
+
+        if [[ -n "$build_version" ]]; then
+            agvtool new-version -all "$build_version" > /dev/null
+        fi
+
+        version_current
+        ;;
+    bump)
+        local current_build
+        current_build=$(version_build)
+        agvtool next-version -all > /dev/null
+
+        # Workaround for agvtool dropping leading zeros (e.g. 010001)
+        local first_char="${current_build:0:1}"
+        if [[ "$first_char" == "0" ]]; then
+            local new_build
+            new_build=$(version_build)
+            agvtool new-version -all "0${new_build}" > /dev/null
+        fi
+
+        version_current
+        ;;
+    *)
+        version_current
+        ;;
+esac

--- a/.config/zsh/functions/version_build
+++ b/.config/zsh/functions/version_build
@@ -1,0 +1,30 @@
+#!/usr/bin/env zsh
+
+# version_build - Displays the project (aka build) version of the current Xcode project
+local plistbuddy=/usr/libexec/PlistBuddy
+local build_setting_name="CURRENT_PROJECT_VERSION"
+
+local project_file
+project_file=$(find . -maxdepth 2 -name "project.pbxproj" -path "*xcodeproj*" 2>/dev/null | head -1)
+if [[ -z "$project_file" ]]; then
+    echo "No xcodeproj found in current directory" >&2
+    return 1
+fi
+
+local root_object
+root_object=$("$plistbuddy" -c "Print :rootObject" "$project_file")
+
+local build_config_list
+build_config_list=$("$plistbuddy" -c "Print :objects:$root_object:buildConfigurationList" "$project_file")
+
+local project_versions=()
+local index
+for index in $(seq 0 10); do
+    local config
+    config=$("$plistbuddy" -c "Print :objects:$build_config_list:buildConfigurations:$index" "$project_file" 2>/dev/null) || break
+    local ver
+    ver=$("$plistbuddy" -c "Print :objects:$config:buildSettings:$build_setting_name" "$project_file" 2>/dev/null)
+    [[ -n "$ver" ]] && project_versions+=("$ver")
+done
+
+printf '%s\n' "${project_versions[@]}" | sort -u | head -1

--- a/.config/zsh/functions/version_current
+++ b/.config/zsh/functions/version_current
@@ -1,0 +1,4 @@
+#!/usr/bin/env zsh
+
+# version_current - Displays Xcode project version information
+echo "$(version_market) ($(version_build))"

--- a/.config/zsh/functions/version_market
+++ b/.config/zsh/functions/version_market
@@ -1,0 +1,30 @@
+#!/usr/bin/env zsh
+
+# version_market - Displays the marketing version of the current Xcode project
+local plistbuddy=/usr/libexec/PlistBuddy
+local build_setting_name="MARKETING_VERSION"
+
+local project_file
+project_file=$(find . -maxdepth 2 -name "project.pbxproj" -path "*xcodeproj*" 2>/dev/null | head -1)
+if [[ -z "$project_file" ]]; then
+    echo "No xcodeproj found in current directory" >&2
+    return 1
+fi
+
+local root_object
+root_object=$("$plistbuddy" -c "Print :rootObject" "$project_file")
+
+local build_config_list
+build_config_list=$("$plistbuddy" -c "Print :objects:$root_object:buildConfigurationList" "$project_file")
+
+local marketing_versions=()
+local index
+for index in $(seq 0 10); do
+    local config
+    config=$("$plistbuddy" -c "Print :objects:$build_config_list:buildConfigurations:$index" "$project_file" 2>/dev/null) || break
+    local ver
+    ver=$("$plistbuddy" -c "Print :objects:$config:buildSettings:$build_setting_name" "$project_file" 2>/dev/null)
+    [[ -n "$ver" ]] && marketing_versions+=("$ver")
+done
+
+printf '%s\n' "${marketing_versions[@]}" | sort -u | head -1

--- a/.config/zsh/functions/xccheck
+++ b/.config/zsh/functions/xccheck
@@ -1,0 +1,8 @@
+#!/usr/bin/env zsh
+
+# xccheck - Validates Xcode application binary integrity using spctl
+local xcode_version
+for xcode_version in $(xclist -1); do
+    echo "Checking integrity of $xcode_version"
+    spctl --assess --verbose "$xcode_version"
+done

--- a/.config/zsh/functions/xclicense
+++ b/.config/zsh/functions/xclicense
@@ -1,0 +1,4 @@
+#!/usr/bin/env zsh
+
+# xclicense - Agree to the Xcode license
+sudo xcodebuild -license accept

--- a/.config/zsh/functions/xclist
+++ b/.config/zsh/functions/xclist
@@ -1,0 +1,35 @@
+#!/usr/bin/env zsh
+
+# xclist - Prints a clean list of paths for all installed versions of Xcode
+#
+# Options:
+# -1 (The numeric digit 'one'.) Force output to be one entry per line.
+local option=$1
+local app_dirs=(/Applications ~/Applications)
+local xcodes=()
+
+local app_dir
+for app_dir in "${app_dirs[@]}"; do
+    local matches=("$app_dir"/Xcode*.app)
+    [[ -e "${matches[1]}" ]] && xcodes+=("${matches[@]}")
+done
+
+# One entry per line, no colors (non-interactive or -1 flag)
+if [[ ! -t 1 || "$option" == "-1" ]]; then
+    printf '%s\n' "${xcodes[@]}"
+    return
+fi
+
+# Colorized output showing symlink target
+local xcode_path
+for xcode_path in "${xcodes[@]}"; do
+    local link_target
+    link_target=$(readlink "$xcode_path")
+    if [[ -n "$link_target" ]]; then
+        # Symlinks in magenta
+        printf '\033[35m%s\033[0m -> %s\n' "$xcode_path" "$link_target"
+    else
+        # Directories in blue
+        printf '\033[34m%s\033[0m\n' "$xcode_path"
+    fi
+done

--- a/.config/zsh/functions/xcss
+++ b/.config/zsh/functions/xcss
@@ -1,0 +1,4 @@
+#!/usr/bin/env zsh
+
+# xcss - Select a different version of Xcode
+sudo xcode-select --switch "$@"

--- a/.config/zsh/functions/xcswitch
+++ b/.config/zsh/functions/xcswitch
@@ -1,0 +1,41 @@
+#!/usr/bin/env zsh
+
+# xcswitch - Switch the active version of Xcode
+local xcode_version=$1
+
+if ! user_is_admin; then
+    echo "You must be an admin to run this command."
+    return 1
+fi
+
+if [[ -z "$xcode_version" ]]; then
+    echo "Usage: xcswitch <xcode_version>"
+    echo "Version format: 8.3.2"
+    return 1
+fi
+
+local xcode_path=/Applications/Xcode-$xcode_version.app
+if [[ ! -e "$xcode_path" ]]; then
+    echo "$xcode_path does not exist."
+    return 2
+fi
+
+echo "Activating Xcode Version: $xcode_version"
+
+# Switch the version of Xcode on the system.
+xcss "$xcode_path"
+
+# Create an Xcode.app symlink so tools that assume Xcode was installed via the
+# MAS use the correct version.
+pushd /Applications || return
+
+# -h    If the link_name or link_dirname is a symbolic link, do not follow it.
+# -f    If the proposed link already exists, unlink it so the link may occur.
+# -s    Create a symbolic link.
+# -v    Verbose, showing files as they are processed.
+ln -hfsv "$(basename "$xcode_path")" Xcode.app
+
+popd || return
+
+xclist
+echo "Activated $(xcsp | head -1)"

--- a/.config/zsh/functions/xcv
+++ b/.config/zsh/functions/xcv
@@ -1,0 +1,118 @@
+#!/usr/bin/env zsh
+
+# xcv - Displays the version of the currently selected Xcode
+local short_flag=$1
+
+local active_version
+active_version=$(xcode-select -p)
+
+if [[ "$active_version" == "/Library/Developer/CommandLineTools" ]]; then
+    printf '%s - ' "$active_version"
+    pkgutil --pkg-info=com.apple.pkg.DevSDK \
+        | grep version \
+        | awk '{print $2}'
+    return
+fi
+
+local version_plist="${active_version/Developer/}version.plist"
+
+if [[ ! -f "$version_plist" ]]; then
+    echo "Plist not found: $version_plist" >&2
+    return 1
+fi
+
+# Parse for marketing version
+local marketing_version
+marketing_version=$(
+    plutil -p "$version_plist" \
+        | grep CFBundleShortVersionString \
+        | sed 's/[^0-9\.]//g'
+)
+
+# Print only the marketing version if -s flag given
+if [[ "$short_flag" == "-s" ]]; then
+    echo "$marketing_version"
+    return
+fi
+
+# Parse for build version
+local build_version
+build_version=$(
+    plutil -p "$version_plist" \
+        | grep ProductBuildVersion \
+        | awk '{print $3}' \
+        | sed 's/"//g'
+)
+
+# Check if this is a beta build
+local beta_version=""
+case "$build_version" in
+    # 10.0
+    10L176w)  beta_version="beta 1 " ;;
+    10L177m)  beta_version="beta 2 " ;;
+    10L201y)  beta_version="beta 3 " ;;
+    10L213o)  beta_version="beta 4 " ;;
+    10L221o)  beta_version="beta 5 " ;;
+    10L232m)  beta_version="beta 6 " ;;
+    10A254a)  beta_version="GM seed " ;;
+    # 10.1
+    10O23ud)  beta_version="beta 1 " ;;
+    10O35n)   beta_version="beta 2 " ;;
+    10O45e)   beta_version="beta 3 " ;;
+    # 10.2
+    10P82s)   beta_version="beta 1 " ;;
+    10P91b)   beta_version="beta 2 " ;;
+    10P99q)   beta_version="beta 3 " ;;
+    10P107d)  beta_version="beta 4 " ;;
+    # 11.0
+    11M336w)  beta_version="beta 1 " ;;
+    11M337n)  beta_version="beta 2 " ;;
+    11M362v)  beta_version="beta 3 " ;;
+    11M374r)  beta_version="beta 4 " ;;
+    11M382q)  beta_version="beta 5 " ;;
+    11M392q)  beta_version="beta 6 " ;;
+    11M392r)  beta_version="beta 7 " ;;
+    11A419c)  beta_version="GM seed 1 " ;;
+    # 11.1
+    # 11A1027 - GM became GA
+    # 11.2
+    11B41)    beta_version="beta 1 " ;;
+    11B44)    beta_version="beta 2 " ;;
+    # 11.2.1
+    11B53)    beta_version="GM seed " ;;
+    # 11.3
+    11C24b)   beta_version="beta 1 " ;;
+    # 11.4
+    11N111s)  beta_version="beta 1 " ;;
+    11N123k)  beta_version="beta 2 " ;;
+    # 12.0
+    12A6159)  beta_version="beta 1 " ;;
+    12A6163b) beta_version="beta 2 " ;;
+    12A8169g) beta_version="beta 3 " ;;
+    12A8179i) beta_version="beta 4 " ;;
+    12A8189h) beta_version="beta 5 " ;;
+    12A8189n) beta_version="beta 6 " ;;
+    # 12.1.1
+    12A7605b) beta_version="RC " ;;
+    # 12.2
+    12B5044c) beta_version="RC " ;;
+    # 13.0
+    13A5154h) beta_version="beta 1 " ;;
+    13A5155e) beta_version="beta 2 " ;;
+    13A5192j) beta_version="beta 3 " ;;
+    13A5201i) beta_version="beta 4 " ;;
+    13A5212g) beta_version="beta 5 " ;;
+    # 13.3
+    13E5086k) beta_version="beta 1 " ;;
+    13E5095k) beta_version="beta 2 " ;;
+    13E5104i) beta_version="beta 3 " ;;
+    # 14.0
+    14A5228q) beta_version="beta 1 " ;;
+    14A5229c) beta_version="beta 2 " ;;
+    14A5270f) beta_version="beta 3 " ;;
+    14A5284g) beta_version="beta 4 " ;;
+    14A5294e) beta_version="beta 5 " ;;
+    14A5294g) beta_version="beta 6 " ;;
+esac
+
+echo "$marketing_version $beta_version($build_version)"

--- a/.config/zsh/functions/xcvall
+++ b/.config/zsh/functions/xcvall
@@ -1,0 +1,8 @@
+#!/usr/bin/env zsh
+
+# xcvall - Lists versions of all installed copies of Xcode
+mdfind kMDItemCFBundleIdentifier=com.apple.dt.Xcode
+
+echo
+echo "CLI tools"
+pkginfo com.apple.pkg.CLTools_Executables

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,7 @@ sg --pattern 'function_name' --lang fish
 - **Never force push** to main/master
 - **GPG commit signing** enabled
 - **No `--no-verify`** — Never bypass pre-commit hooks
+- **PR body format:** Ticket references (e.g., `Resolves DEVX-123`) and links to related PRs must appear above the first heading in the PR body, on their own lines, so they are immediately visible
 
 ### When Hooks Fail
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,6 +210,10 @@ sg --pattern 'function_name' --lang fish
 
 - **Conventional commits:** `feat:`, `fix:`, `docs:`, `chore:`, etc. (imperative mood, present tense)
 - **Feature branches:** Topic-based naming (e.g., `ben/fix-authentication`)
+- **Branch tracking:** When pushing a new branch, always use an explicit refspec so remote tracking targets the same branch name — never the base branch. `main` is protected and cannot be pushed to.
+  ```bash
+  git push -u <remote> <branch>:<branch>
+  ```
 - **Never force push** to main/master
 - **GPG commit signing** enabled
 - **No `--no-verify`** — Never bypass pre-commit hooks

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -8,7 +8,7 @@ This document tracks the implementation status of all shell functions and aliase
 
 **Shell Statistics:**
 
-- Zsh: 365 functions (primary shell)
+- Zsh: 384 functions (primary shell)
 - Fish: 684 functions (secondary shell, most comprehensive)
 - Nushell: 102 aliases/functions (actively being configured)
 - Bash: 12 functions (minimal usage)
@@ -17,10 +17,10 @@ This document tracks the implementation status of all shell functions and aliase
 
 - Implemented in all 4 shells: 9
 - Implemented in 3 shells: 39
-- Implemented in 2 shells: 235
-- Implemented in 1 shell only: 431
+- Implemented in 2 shells: 254
+- Implemented in 1 shell only: 412
 
-**Functions Implemented in Multiple Shells:** 273
+**Functions Implemented in Multiple Shells:** 292
 
 ## Status Legend
 
@@ -169,7 +169,7 @@ This document tracks the implementation status of all shell functions and aliase
 | `clv`                       | ➖  | ✅   | ➖  | ➖   | Quick dir navigation                                 |
 | `cmtne`                     | ✅  | ✅   | ✅  | ➖   | Commit with default message                          |
 | `cmt`                       | ✅  | ✅   | ✅  | ➖   | Commit with message                                  |
-| `codesign_verify`           | ➖  | ✅   | ➖  | ➖   | Verify the codesign of a bundle                      |
+| `codesign_verify`           | ➖  | ✅   | ✅  | ➖   | Verify the codesign of a bundle                      |
 | `col1`                      | ➖  | ✅   | ✅  | ➖   | Prints the first column of input (first argument)    |
 | `commit_count`              | ✅  | ✅   | ✅  | ➖   | Count commits by date for a branch                   |
 | `commit`                    | ✅  | ✅   | ✅  | ➖   | Perform a git commit                                 |
@@ -253,7 +253,7 @@ This document tracks the implementation status of all shell functions and aliase
 | `dsr`                       | ➖  | ✅   | ✅  | ➖   | Remove docker services                               |
 | `dss`                       | ➖  | ✅   | ✅  | ➖   | Scale replicated docker services                     |
 | `dsym_uuid`                 | ➖  | ✅   | ➖  | ➖   | Fish function                                        |
-| `dsyminfo`                  | ➖  | ✅   | ➖  | ➖   | Displays information for a Dwarf symbol file         |
+| `dsyminfo`                  | ➖  | ✅   | ✅  | ➖   | Displays information for a Dwarf symbol file         |
 | `dtc`                       | ➖  | ✅   | ✅  | ➖   | Git difftool on cached/staged changes                |
 | `dt`                        | ➖  | ✅   | ✅  | ➖   | Git difftool shorthand                               |
 | `dvc`                       | ➖  | ✅   | ✅  | ➖   | Create docker volume                                 |
@@ -291,7 +291,7 @@ This document tracks the implementation status of all shell functions and aliase
 | `find_appcast`              | ➖  | ✅   | ➖  | ➖   | Alias for Homebrew find_appcast script               |
 | `find_dotnet`               | ➖  | ✅   | ➖  | ➖   | Locates all copies of dotnet command                 |
 | `find_file`                 | ➖  | ✅   | ➖  | ➖   | Finds files under given base_dir                     |
-| `finddsym`                  | ➖  | ✅   | ➖  | ➖   | Locates a dSYM file with the given UUID              |
+| `finddsym`                  | ➖  | ✅   | ✅  | ➖   | Locates a dSYM file with the given UUID              |
 | `finds`                     | ➖  | ➖   | ➖  | ➖   | Zsh function                                         |
 | `findup`                    | ➖  | ✅   | ➖  | ➖   | Recursively searches up directory tree               |
 | `firewall_allow_nginx`      | ➖  | ✅   | ➖  | ➖   | Configures the firewall to allow incoming connecti   |
@@ -398,7 +398,7 @@ This document tracks the implementation status of all shell functions and aliase
 | `init`                      | ✅  | ✅   | ➖  | ➖   | Initialize new git repo in current/optional dir      |
 | `install_choices`           | ➖  | ✅   | ➖  | ➖   | Prints the choices available in the given installa   |
 | `install_powerline_prompt`  | ➖  | ➖   | ➖  | ➖   | Zsh function                                         |
-| `iphones`                   | ➖  | ✅   | ➖  | ➖   | Fish function                                        |
+| `iphones`                   | ➖  | ✅   | ✅  | ➖   | Show connected iOS devices                           |
 | `ip`                        | ➖  | ✅   | ➖  | ➖   | Show the current IPv4 address                        |
 | `is_arm`                    | ➖  | ✅   | ✅  | ➖   | Tests whether current system is arm                  |
 | `is_bash_login`             | ➖  | ✅   | ➖  | ➖   | Fish function                                        |
@@ -543,11 +543,11 @@ This document tracks the implementation status of all shell functions and aliase
 | `prefs`                     | ➖  | ✅   | ➖  | ➖   | Opens System Preferences to specific pane            |
 | `prettyjson`                | ➖  | ✅   | ✅  | ➖   | Prints a formatted version of a JSON file            |
 | `print_profile`             | ➖  | ➖   | ➖  | ➖   | Zsh function                                         |
-| `profile_id`                | ➖  | ✅   | ➖  | ➖   | Extracts the UUID from a .mobileprovision profile    |
+| `profile_id`                | ➖  | ✅   | ✅  | ➖   | Extracts the UUID from a .mobileprovision profile    |
 | `provdir`                   | ➖  | ➖   | ➖  | ➖   | Zsh function                                         |
 | `provisioning_dir`          | ➖  | ✅   | ➖  | ➖   | Open the Provisioning Profiles directory in Finder   |
 | `provisioning_print`        | ➖  | ✅   | ✅  | ➖   | Prints a text version of a provisioning profile      |
-| `provisioning_uuid`         | ➖  | ✅   | ➖  | ➖   | Prints the UUID                                      |
+| `provisioning_uuid`         | ➖  | ✅   | ✅  | ➖   | Prints the UUID from a provisioning profile          |
 | `prunep`                    | ➖  | ✅   | ➖  | ➖   | Prunes phatblat remote                               |
 | `prunesvn`                  | ➖  | ✅   | ➖  | ➖   | Delete the .svn directories from a directory heira   |
 | `prune`                     | ✅  | ✅   | ✅  | ➖   | Prune obsolete remote branches on given remote       |
@@ -631,8 +631,8 @@ This document tracks the implementation status of all shell functions and aliase
 | `showjdks`                  | ➖  | ➖   | ➖  | ➖   | Zsh function                                         |
 | `showsvn`                   | ➖  | ✅   | ✅  | ➖   | Show .svn directories in the current directory tre   |
 | `show`                      | ✅  | ✅   | ✅  | ➖   | Git show                                             |
-| `signing_cert_details`      | ➖  | ✅   | ➖  | ➖   | Prints signing certificate details                   |
-| `simclean`                  | ➖  | ✅   | ➖  | ➖   | Deletes all unavailable simulators                   |
+| `signing_cert_details`      | ➖  | ✅   | ✅  | ➖   | Prints signing certificate details                   |
+| `simclean`                  | ➖  | ✅   | ✅  | ➖   | Deletes all unavailable simulators                   |
 | `skip`                      | ➖  | ✅   | ✅  | ➖   | Skip current commit in git rebase/cherry-pick        |
 | `sortdiff`                  | ➖  | ✅   | ➖  | ➖   | Filter and sort a git diff showing only the change   |
 | `sort`                      | ➖  | ✅   | ➖  | ➖   | Wrapper for sort forcing byte ordering               |
@@ -720,11 +720,11 @@ This document tracks the implementation status of all shell functions and aliase
 | `user_present`              | ➖  | ✅   | ✅  | ➖   | Indicates whether a user is present                  |
 | `user`                      | ➖  | ✅   | ✅  | ➖   | Displays info about current user                     |
 | `uuid_from_profile`         | ➖  | ➖   | ➖  | ➖   | Zsh function                                         |
-| `version_build`             | ➖  | ✅   | ➖  | ➖   | Displays project version of current Xcode project    |
-| `version_current`           | ➖  | ✅   | ➖  | ➖   | Displays Xcode project version information           |
+| `version_build`             | ➖  | ✅   | ✅  | ➖   | Displays project version of current Xcode project    |
+| `version_current`           | ➖  | ✅   | ✅  | ➖   | Displays Xcode project version information           |
 | `version_enable`            | ➖  | ✅   | ➖  | ➖   | Runs enable-versioning.rb ruby script                |
-| `version_market`            | ➖  | ✅   | ➖  | ➖   | Displays marketing version of current Xcode project  |
-| `version`                   | ➖  | ✅   | ➖  | ➖   | Manage version numbers for Xcode project             |
+| `version_market`            | ➖  | ✅   | ✅  | ➖   | Displays marketing version of current Xcode project  |
+| `version`                   | ➖  | ✅   | ✅  | ➖   | Manage version numbers for Xcode project             |
 | `vimode`                    | ➖  | ✅   | ➖  | ➖   | Enable VI mode key bindings                          |
 | `warpify`                   | ➖  | ✅   | ➖  | ➖   | https://docs.warp.dev/features/subshells#automatic   |
 | `whichjdk`                  | ➖  | ➖   | ➖  | ➖   | Zsh function                                         |
@@ -734,26 +734,26 @@ This document tracks the implementation status of all shell functions and aliase
 | `xcblist`                   | ➖  | ✅   | ➖  | ➖   | Lists info about first Xcode project found           |
 | `xcbschemes`                | ➖  | ✅   | ✅  | ➖   | Displays schemes for Xcode project                   |
 | `xcb`                       | ➖  | ✅   | ➖  | ➖   | Alias for xcodebuild                                 |
-| `xccheck`                   | ➖  | ✅   | ➖  | ➖   | Validates Xcode application binary integrity using   |
+| `xccheck`                   | ➖  | ✅   | ✅  | ➖   | Validates Xcode application binary integrity using   |
 | `xcdevices`                 | ➖  | ✅   | ➖  | ➖   | Fish function                                        |
 | `xcdl`                      | ➖  | ✅   | ➖  | ➖   | Fish function                                        |
 | `xcfl`                      | ➖  | ✅   | ➖  | ➖   | Fish function                                        |
 | `xcinit`                    | ➖  | ✅   | ✅  | ➖   | Runs Xcode new_project.rb ruby script                |
-| `xclicense`                 | ➖  | ✅   | ➖  | ➖   | Agree to Xcode license                               |
-| `xclist`                    | ➖  | ✅   | ➖  | ➖   | Prints a clean list of paths for all installed ver   |
+| `xclicense`                 | ➖  | ✅   | ✅  | ➖   | Agree to Xcode license                               |
+| `xclist`                    | ➖  | ✅   | ✅  | ➖   | Prints a clean list of paths for all installed ver   |
 | `xcode_plugin_update_uuid`  | ➖  | ➖   | ➖  | ➖   | Zsh function                                         |
 | `xcodeplugin`               | ➖  | ✅   | ➖  | ➖   | Quick nav to xcodePlugin project                     |
 | `xcodes`                    | ➖  | ➖   | ➖  | ➖   | Zsh function                                         |
 | `xconfd`                    | ➖  | ✅   | ✅  | ➖   | Quick dir navigation to nginx config dir             |
 | `xconf`                     | ➖  | ✅   | ✅  | ➖   | Edit nginx configuration files                       |
 | `xcsp`                      | ➖  | ✅   | ✅  | ➖   | Show the currently selected version of Xcode         |
-| `xcss`                      | ➖  | ✅   | ➖  | ➖   | Select a different version of Xcode                  |
-| `xcswitch`                  | ➖  | ✅   | ➖  | ➖   | Switch the active version of Xcode                   |
-| `xcvall`                    | ➖  | ✅   | ➖  | ➖   | Lists versions of all installed copies of Xcode      |
+| `xcss`                      | ➖  | ✅   | ✅  | ➖   | Select a different version of Xcode                  |
+| `xcswitch`                  | ➖  | ✅   | ✅  | ➖   | Switch the active version of Xcode                   |
+| `xcvall`                    | ➖  | ✅   | ✅  | ➖   | Lists versions of all installed copies of Xcode      |
 | `xcvmcache`                 | ➖  | ✅   | ➖  | ➖   | xcvmcache                                            |
 | `xcvmget`                   | ➖  | ✅   | ✅  | ➖   | xcvmget                                              |
 | `xcvmlist`                  | ➖  | ✅   | ➖  | ➖   | xcvmlist                                             |
-| `xcv`                       | ➖  | ✅   | ➖  | ➖   | Displays version of currently selected Xcode         |
+| `xcv`                       | ➖  | ✅   | ✅  | ➖   | Displays version of currently selected Xcode         |
 | `xc`                        | ➖  | ✅   | ✅  | ➖   | Xcode wrapper function                               |
 | `xcode`                     | ➖  | ➖   | ✅  | ➖   | Installs and updates Xcode                           |
 | `xerror`                    | ➖  | ✅   | ✅  | ➖   | Read nginx error log                                 |

--- a/justfile
+++ b/justfile
@@ -163,6 +163,11 @@ install:
 upgrade *args:
     mise upgrade --bump {{ args }}
 
+# Upgrades mise itself
+[group('configuration')]
+upgrade-mise:
+    mise self-update
+
 # Upgrades each outdated tool and commits the version change individually
 [group('configuration')]
 upgrade-commits:

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,12 @@
   "extends": ["config:recommended"],
   "assignAutomerge": true,
   "assignees": ["phatblat"],
+  "labels": ["dependencies"],
   "platformAutomerge": true,
+  "mise": {
+    "enabled": true,
+    "fileMatch": ["\\.config/mise/config\\.toml$"]
+  },
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch"],
@@ -11,6 +16,18 @@
       "automerge": true,
       "automergeStrategy": "rebase",
       "automergeType": "pr"
+    },
+    {
+      "description": "Group all mise tool updates",
+      "matchManagers": ["mise"],
+      "groupName": "mise tools"
+    },
+    {
+      "description": "Group all npm tool updates",
+      "matchManagers": ["mise"],
+      "matchDepPatterns": ["^npm:"],
+      "groupName": "mise npm tools"
     }
-  ]
+  ],
+  "schedule": ["before 9am on monday"]
 }


### PR DESCRIPTION
## Summary

- Port ~19 Xcode/iOS tooling functions from Fish to Zsh (codesign_verify, dsyminfo, xcswitch, xcv, etc.)
- Add `upgrade-mise` just recipe for self-updating mise
- Add renovate config for automated mise dependency updates
- Add branch tracking instruction to prevent accidental push to protected main
- Require ticket references above first heading in PR bodies for visibility

## Test plan

- [ ] Verify new Zsh functions load correctly (`autoload -Uz <func>; <func>`)
- [ ] Run `just upgrade-mise` to confirm mise self-update works
- [ ] Confirm `just format` and `just lint` pass
- [ ] Review PR body templates in commands/skills for correct ticket placement

🤖 Generated with [Claude Code](https://claude.com/claude-code)