### PR TITLE
chore: bump vfox-gcloud 563.0.0 → 564.0.0

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -20,7 +20,7 @@
 "npm:yarn" = "1.22.22"
 "pipx:pyright" = "1.1.408"
 "pipx:python-lsp-server" = "1.14.0"
-"vfox:mise-plugins/vfox-gcloud" = "563.0.0"
+"vfox:mise-plugins/vfox-gcloud" = "564.0.0"
 act = "0.2.87"
 actionlint = "1.7.12"
 awscli = { version = "2.34.24", symlink_bins = "true" }


### PR DESCRIPTION
## Summary
- Bump vfox:mise-plugins/vfox-gcloud from 563.0.0 to 564.0.0

## Test plan
- [x] Verify `mise install` completes successfully
- [x] Confirm `gcloud --version` reports expected version

🤖 Generated with [Claude Code](https://claude.com/claude-code)