### PR TITLE
chore: wednesday 2026-04-29

### DIFF
--- a/.warp/settings.toml
+++ b/.warp/settings.toml
@@ -101,7 +101,7 @@ vim_mode_enabled = false
 startup_shell_override = "zsh"
 
 [session.new_session_shell_override ]
-executable = "/opt/homebrew/Cellar/zsh/5.9/bin/zsh"
+executable = "/opt/homebrew/bin/zsh"
 
 [session.working_directory_config]
 advanced_mode = true

--- a/.warp/settings.toml
+++ b/.warp/settings.toml
@@ -183,3 +183,6 @@ is_password_prompt_enabled = true
 long_running_threshold = 30
 mode = "enabled"
 play_notification_sound = true
+
+[warp_drive]
+enabled = false

--- a/.warp/settings.toml
+++ b/.warp/settings.toml
@@ -98,8 +98,10 @@ vim_status_bar = false
 vim_mode_enabled = false
 
 [session]
-new_session_shell_override = "system_default"
 startup_shell_override = "zsh"
+
+[session.new_session_shell_override ]
+executable = "/opt/homebrew/Cellar/zsh/5.9/bin/zsh"
 
 [session.working_directory_config]
 advanced_mode = true

--- a/justfile
+++ b/justfile
@@ -78,8 +78,13 @@ list-missing:
 
 # Lists available upgrades
 [group('info')]
-outdated:
+outdated: outdated-uv
     mise outdated --bump
+
+# Lists outdated uv tools
+[group('info')]
+outdated-uv:
+    uv tool list --outdated
 
 # Lists installed Nix packages
 [group('info')]
@@ -164,7 +169,7 @@ install:
 
 # Common upgrades
 [group('configuration')]
-upgrade: upgrade-mise update-brew upgrade-brew
+upgrade: upgrade-mise update-brew upgrade-brew upgrade-uv-tools
 
 # Upgrades tools using mise
 [group('configuration')]
@@ -204,6 +209,11 @@ update-brew:
 [group('configuration')]
 upgrade-brew *args:
     brew upgrade {{ args }}
+
+# Upgrades all uv-managed tools
+[group('configuration')]
+upgrade-uv-tools:
+    uv tool upgrade --all
 
 # Updates home-manager flake and rebuilds configuration
 [group('nix')]


### PR DESCRIPTION
## Summary
- Override Warp's new session shell to use Homebrew zsh instead of system default
- Add `outdated-uv` and `upgrade-uv-tools` just recipes for managing uv-installed Python tools
- Disable Warp Drive feature

## Test plan
- [x] Verify new Warp sessions launch with Homebrew zsh
- [x] Run `just outdated` and confirm uv tool checks are included
- [ ] Run `just upgrade` and confirm uv tool upgrades are included
- [x] Confirm Warp Drive is disabled in Warp settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)