### PR TITLE
chore: thursday 2026-05-01

### DIFF
--- a/.config/starship.toml
+++ b/.config/starship.toml
@@ -39,8 +39,17 @@ disabled = false
 [package]
 disabled = false
 
+[python]
+disabled = true
+
 [shell]
 disabled = false
+
+[java]
+disabled = true
+
+[kotlin]
+disabled = true
 
 [status]
 disabled = true


### PR DESCRIPTION
Daily dotfiles branch for thursday, 2026-05-01.

## Summary
- Disable slow starship modules (java, kotlin, python) that were adding ~800ms prompt latency in the home directory

## Test plan
- [x] Verify prompt renders in under 500ms in home directory
- [x] Confirm git branch still shows in starship prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)