### PR TITLE
Monday dotfiles updates

### DIFF
--- a/.config/zsh/functions/fork
+++ b/.config/zsh/functions/fork
@@ -1,0 +1,4 @@
+#!/usr/bin/env zsh
+
+# fork - Launch Fork.app from the terminal (inherits mise PATH)
+open -a Fork "$@"

--- a/.gitignore
+++ b/.gitignore
@@ -555,6 +555,7 @@ Library/Application Support/Many Tricks/
 Library/Application Support/Microsoft*/
 Library/Application Support/Microsoft/
 Library/Application Support/MobileSync/
+Library/Application Support/Moonlock/
 Library/Application Support/Motion/
 Library/Application Support/Mozilla/
 Library/Application Support/Msty/

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -314,6 +314,7 @@ This document tracks the implementation status of all shell functions and aliase
 | `flushdns`                  | ➖  | ✅   | ✅  | ➖   | Flush macOS DNS cache                                |
 | `fl`                        | ➖  | ✅   | ➖  | ➖   | List functions                                       |
 | `fn`                        | ➖  | ✅   | ➖  | ➖   | Create a new function                                |
+| `fork`                      | ➖  | ➖   | ✅  | ➖   | Launch Fork.app (inherits mise PATH)                 |
 | `format-patch`              | ➖  | ✅   | ✅  | ➖   | Git format-patch wrapper                             |
 | `format`                    | ➖  | ✅   | ➖  | ➖   | Fish function                                        |
 | `fq`                        | ➖  | ✅   | ✅  | ➖   | Check for existence of a function                    |


### PR DESCRIPTION
## Summary
- **feat(zsh):** Add `fork` function to launch Fork.app with mise PATH inherited
- **chore:** Ignore `Library/Application Support/Moonlock/`

## Test plan
- [x] Run `fork` in a new zsh session to verify Fork.app launches

🤖 Generated with [Claude Code](https://claude.com/claude-code)