### PR TITLE
chore(justfile): add diagnostic log for lint-python

### DIFF
--- a/justfile
+++ b/justfile
@@ -379,6 +379,7 @@ lint-gitignore:
 # Lints Python scripts with ruff
 [group('checks')]
 lint-python:
+    @echo "Linting Python scripts..."
     ruff check ~/scripts/sort-tools.py
 
 # Lints Zsh functions with shellcheck


### PR DESCRIPTION
## Summary
Adds a diagnostic log message before the `ruff` linter runs during the `lint-python` recipe. This clarifies which tool is producing the subsequent success message and fixes the confusing order where "All checks passed!" appeared at the start of `just lint` output.

## Changes
- Add "Linting Python scripts..." message to lint-python recipe for clarity