### PR TITLE
chore: weekend 2026-07-04

### DIFF
--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -3,8 +3,10 @@
 # ghostty +show-config --default --docs | bat --language sh
 
 # Shell
-initial-command = /opt/homebrew/bin/nu
-command = /opt/homebrew/bin/nu
+# Use the stable mise shim, not a version-pinned install path or a
+# nonexistent /opt/homebrew/bin/nu — survives `mise upgrade nu` bumps.
+initial-command = /Users/phatblat/.local/share/mise/shims/nu
+command = /Users/phatblat/.local/share/mise/shims/nu
 
 # Style
 # ghostty +list-themes


### PR DESCRIPTION
## Summary
Ghostty's terminal shell was pointed at a hardcoded Homebrew path for nushell, which breaks once the shell is managed by mise instead.

## Changes
- Point ghostty's `initial-command`/`command` at the mise shim for `nu` instead of the version-pinned/nonexistent `/opt/homebrew/bin/nu` path, so it keeps working across `mise upgrade nu` bumps