### PR TITLE
chore: tuesday 2026-07-07

### DIFF
--- a/.agents/harness/commands/pr/post-findings.md
+++ b/.agents/harness/commands/pr/post-findings.md
@@ -127,7 +127,7 @@ comment_url=$(gh pr comment <pr_number> --body "<description>
 _Originally at: <url>_")
 ```
 
-Record `{number, description, comment_url, kind}` for each finding (`kind` = `suggestion` | `inline` | `general`) — Step 5 uses these. Report success or fallback for each finding.
+Record `{number, description, path, line, comment_url, kind}` for each finding (`kind` = `suggestion` | `inline` | `general`) — Step 5 uses these. Report success or fallback for each finding.
 
 ### 5. Record in Today's Daily Note
 
@@ -162,12 +162,12 @@ gh pr view <pr_number> --json title,author --jq '"\(.title)|@\(.author.login)"'
 
 ```markdown
 - [<owner>/<repo>#<pr_number>](<pr_url>) — <PR title> — @<author>
-  - [comment](<comment_url>) — <brief finding description>
-  - [comment](<comment_url>) — <brief finding description>
+  - [<file>:<line>](<comment_url>) — <brief finding description>
+  - [<file>:<line>](<comment_url>) — <brief finding description>
 ```
 
-- Link text is `<owner>/<repo>#<pr_number>` (e.g. `getditto/forge#887`), linked to `<pr_url>`.
-- One sub-bullet per finding posted in Step 4, using that finding's captured `comment_url`. For a finding that fell back to a general comment, append ` (general)` to its sub-bullet.
+- The PR line's link text is `<owner>/<repo>#<pr_number>` (e.g. `getditto/forge#887`), linked to `<pr_url>`.
+- One sub-bullet per finding posted in Step 4. Its link text is `<file>:<line>` — the **basename** of the finding's `path` (filename only, not the full path) and its anchor `line`, e.g. `CalendarComponent.swift:209` — linked to that finding's captured `comment_url`. For a finding that fell back to a general comment, append ` (general)` to its sub-bullet.
 
 **Append rules:**
 - **PR already listed** (a `- [<owner>/<repo>#<pr_number>](` line exists under `# Reviews`): append the new comment sub-bullets under that existing item — do not repeat the PR line.

--- a/.agents/harness/commands/pr/post-findings.md
+++ b/.agents/harness/commands/pr/post-findings.md
@@ -4,7 +4,7 @@
 description: Post code review findings from /review as inline PR comments
 model: sonnet
 argument_hint: "[finding numbers, e.g. 1,2,4] — omit to post all"
-allowed-tools: Bash(gh:*), Bash(git:*)
+allowed-tools: Bash(gh:*), Bash(git:*), Bash(date:*), Bash(grep:*), Read, Edit
 category: workflow
 ---
 
@@ -100,9 +100,11 @@ The body format depends on `suggestion_type`:
 
 #### Post the comment
 
+Capture the created comment's URL — Step 5 links to it from the daily note.
+
 ```bash
 body="<body from above>"
-gh api repos/{owner}/{repo}/pulls/<pr_number>/comments \
+resp=$(gh api repos/{owner}/{repo}/pulls/<pr_number>/comments \
   --method POST \
   --input - <<EOF
 {
@@ -113,17 +115,67 @@ gh api repos/{owner}/{repo}/pulls/<pr_number>/comments \
   "side": "RIGHT"
 }
 EOF
+)
+comment_url=$(printf '%s' "$resp" | jq -r '.html_url')
 ```
 
-If the `gh api` call returns an error (e.g. line not in diff), fall back to a general PR comment:
+If the `gh api` call returns an error (e.g. line not in diff), fall back to a general PR comment and capture its URL instead:
 
 ```bash
-gh pr comment <pr_number> --body "<description>\n\n_Originally at: <url>_"
+comment_url=$(gh pr comment <pr_number> --body "<description>
+
+_Originally at: <url>_")
 ```
 
-Report success or fallback for each finding.
+Record `{number, description, comment_url, kind}` for each finding (`kind` = `suggestion` | `inline` | `general`) — Step 5 uses these. Report success or fallback for each finding.
 
-### 5. Report Results
+### 5. Record in Today's Daily Note
+
+Append this review to the `# Reviews` section of today's daily note (seeded by `work:start-day`) so the worklog captures which PRs you reviewed and every comment you left.
+
+```bash
+today_date=$(date +%Y-%m-%d)
+today_day=$(date +%A)
+today_year=$(date +%Y)
+note_path="$HOME/2ndBrain/daily-notes/${today_year}/${today_date} ${today_day}.md"
+```
+
+If the note doesn't exist, **skip this step** — do not fail (the comments were already posted). Note the skip in the final report.
+
+If the note exists but has no `# Reviews` section (created from an older template), insert one after the `# Work Items` block:
+
+```markdown
+# Reviews
+
+<!-- pr:post-findings appends reviewed PRs here -->
+
+***
+```
+
+Fetch the PR title and author:
+
+```bash
+gh pr view <pr_number> --json title,author --jq '"\(.title)|@\(.author.login)"'
+```
+
+**Entry format** — each reviewed PR is one top-level list item under `# Reviews`; the comments posted in this run are an indented sub-list beneath it:
+
+```markdown
+- [<owner>/<repo>#<pr_number>](<pr_url>) — <PR title> — @<author>
+  - [comment](<comment_url>) — <brief finding description>
+  - [comment](<comment_url>) — <brief finding description>
+```
+
+- Link text is `<owner>/<repo>#<pr_number>` (e.g. `getditto/forge#887`), linked to `<pr_url>`.
+- One sub-bullet per finding posted in Step 4, using that finding's captured `comment_url`. For a finding that fell back to a general comment, append ` (general)` to its sub-bullet.
+
+**Append rules:**
+- **PR already listed** (a `- [<owner>/<repo>#<pr_number>](` line exists under `# Reviews`): append the new comment sub-bullets under that existing item — do not repeat the PR line.
+- **PR not listed:** insert a new PR item after the `<!-- pr:post-findings appends reviewed PRs here -->` comment (following the next blank line); if that comment is absent, append at the end of the `# Reviews` section, before its `---`.
+
+Use `Edit` to make the change.
+
+### 6. Report Results
 
 ```
 Posted N finding(s) to PR #<pr_number>:
@@ -131,6 +183,8 @@ Posted N finding(s) to PR #<pr_number>:
   ✅ #2 — <brief description> (inline at <path>:<line>)
   ⚠️  #3 — <brief description> (posted as general comment — line not in diff)
 <pr_url>
+
+Daily note: added <N> comment(s) under <owner>/<repo>#<pr_number> in # Reviews (or "new PR entry" / "skipped — run /work:start first")
 ```
 
-Label each as `suggestion`, `inline`, or `general comment` so it's clear which are actionable.
+Label each finding as `suggestion`, `inline`, or `general comment` so it's clear which are actionable.

--- a/.agents/harness/commands/work/start-day.md
+++ b/.agents/harness/commands/work/start-day.md
@@ -53,6 +53,8 @@ ls "${notes_dir}/${today_file}.md" 2>/dev/null && echo "EXISTS" || echo "MISSING
   - `{{date:dddd}}` → today's day name (e.g., `Friday`)
   - `{{date:YYYY-MM-DD dddd}}` → today's full date with day (e.g., `2026-05-29 Friday`)
 
+The template includes a `# Reviews` section seeded with a `<!-- pr:post-findings appends reviewed PRs here -->` placeholder — this is where `/pr:post-findings` records reviewed PRs and the comments left on them. Leave it empty at startup. If today's note already **EXISTS** but predates this section (no `# Reviews` heading), insert one after the `# Work Items` block before continuing.
+
 **Important**: The template's yesterday link `[[{{date:YYYY-MM-DD dddd}}]]` will resolve to TODAY (self-reference). Step 3 fixes this.
 
 ## Step 3: Fix Yesterday Link

--- a/.claude/commands/pr/post-findings.md
+++ b/.claude/commands/pr/post-findings.md
@@ -125,7 +125,7 @@ comment_url=$(gh pr comment <pr_number> --body "<description>
 _Originally at: <url>_")
 ```
 
-Record `{number, description, comment_url, kind}` for each finding (`kind` = `suggestion` | `inline` | `general`) — Step 5 uses these. Report success or fallback for each finding.
+Record `{number, description, path, line, comment_url, kind}` for each finding (`kind` = `suggestion` | `inline` | `general`) — Step 5 uses these. Report success or fallback for each finding.
 
 ### 5. Record in Today's Daily Note
 
@@ -160,12 +160,12 @@ gh pr view <pr_number> --json title,author --jq '"\(.title)|@\(.author.login)"'
 
 ```markdown
 - [<owner>/<repo>#<pr_number>](<pr_url>) — <PR title> — @<author>
-  - [comment](<comment_url>) — <brief finding description>
-  - [comment](<comment_url>) — <brief finding description>
+  - [<file>:<line>](<comment_url>) — <brief finding description>
+  - [<file>:<line>](<comment_url>) — <brief finding description>
 ```
 
-- Link text is `<owner>/<repo>#<pr_number>` (e.g. `getditto/forge#887`), linked to `<pr_url>`.
-- One sub-bullet per finding posted in Step 4, using that finding's captured `comment_url`. For a finding that fell back to a general comment, append ` (general)` to its sub-bullet.
+- The PR line's link text is `<owner>/<repo>#<pr_number>` (e.g. `getditto/forge#887`), linked to `<pr_url>`.
+- One sub-bullet per finding posted in Step 4. Its link text is `<file>:<line>` — the **basename** of the finding's `path` (filename only, not the full path) and its anchor `line`, e.g. `CalendarComponent.swift:209` — linked to that finding's captured `comment_url`. For a finding that fell back to a general comment, append ` (general)` to its sub-bullet.
 
 **Append rules:**
 - **PR already listed** (a `- [<owner>/<repo>#<pr_number>](` line exists under `# Reviews`): append the new comment sub-bullets under that existing item — do not repeat the PR line.

--- a/.claude/commands/pr/post-findings.md
+++ b/.claude/commands/pr/post-findings.md
@@ -2,7 +2,7 @@
 description: Post code review findings from /review as inline PR comments
 model: sonnet
 argument_hint: "[finding numbers, e.g. 1,2,4] — omit to post all"
-allowed-tools: Bash(gh:*), Bash(git:*)
+allowed-tools: Bash(gh:*), Bash(git:*), Bash(date:*), Bash(grep:*), Read, Edit
 category: workflow
 ---
 
@@ -98,9 +98,11 @@ The body format depends on `suggestion_type`:
 
 #### Post the comment
 
+Capture the created comment's URL — Step 5 links to it from the daily note.
+
 ```bash
 body="<body from above>"
-gh api repos/{owner}/{repo}/pulls/<pr_number>/comments \
+resp=$(gh api repos/{owner}/{repo}/pulls/<pr_number>/comments \
   --method POST \
   --input - <<EOF
 {
@@ -111,17 +113,67 @@ gh api repos/{owner}/{repo}/pulls/<pr_number>/comments \
   "side": "RIGHT"
 }
 EOF
+)
+comment_url=$(printf '%s' "$resp" | jq -r '.html_url')
 ```
 
-If the `gh api` call returns an error (e.g. line not in diff), fall back to a general PR comment:
+If the `gh api` call returns an error (e.g. line not in diff), fall back to a general PR comment and capture its URL instead:
 
 ```bash
-gh pr comment <pr_number> --body "<description>\n\n_Originally at: <url>_"
+comment_url=$(gh pr comment <pr_number> --body "<description>
+
+_Originally at: <url>_")
 ```
 
-Report success or fallback for each finding.
+Record `{number, description, comment_url, kind}` for each finding (`kind` = `suggestion` | `inline` | `general`) — Step 5 uses these. Report success or fallback for each finding.
 
-### 5. Report Results
+### 5. Record in Today's Daily Note
+
+Append this review to the `# Reviews` section of today's daily note (seeded by `work:start-day`) so the worklog captures which PRs you reviewed and every comment you left.
+
+```bash
+today_date=$(date +%Y-%m-%d)
+today_day=$(date +%A)
+today_year=$(date +%Y)
+note_path="$HOME/2ndBrain/daily-notes/${today_year}/${today_date} ${today_day}.md"
+```
+
+If the note doesn't exist, **skip this step** — do not fail (the comments were already posted). Note the skip in the final report.
+
+If the note exists but has no `# Reviews` section (created from an older template), insert one after the `# Work Items` block:
+
+```markdown
+# Reviews
+
+<!-- pr:post-findings appends reviewed PRs here -->
+
+***
+```
+
+Fetch the PR title and author:
+
+```bash
+gh pr view <pr_number> --json title,author --jq '"\(.title)|@\(.author.login)"'
+```
+
+**Entry format** — each reviewed PR is one top-level list item under `# Reviews`; the comments posted in this run are an indented sub-list beneath it:
+
+```markdown
+- [<owner>/<repo>#<pr_number>](<pr_url>) — <PR title> — @<author>
+  - [comment](<comment_url>) — <brief finding description>
+  - [comment](<comment_url>) — <brief finding description>
+```
+
+- Link text is `<owner>/<repo>#<pr_number>` (e.g. `getditto/forge#887`), linked to `<pr_url>`.
+- One sub-bullet per finding posted in Step 4, using that finding's captured `comment_url`. For a finding that fell back to a general comment, append ` (general)` to its sub-bullet.
+
+**Append rules:**
+- **PR already listed** (a `- [<owner>/<repo>#<pr_number>](` line exists under `# Reviews`): append the new comment sub-bullets under that existing item — do not repeat the PR line.
+- **PR not listed:** insert a new PR item after the `<!-- pr:post-findings appends reviewed PRs here -->` comment (following the next blank line); if that comment is absent, append at the end of the `# Reviews` section, before its `---`.
+
+Use `Edit` to make the change.
+
+### 6. Report Results
 
 ```
 Posted N finding(s) to PR #<pr_number>:
@@ -129,6 +181,8 @@ Posted N finding(s) to PR #<pr_number>:
   ✅ #2 — <brief description> (inline at <path>:<line>)
   ⚠️  #3 — <brief description> (posted as general comment — line not in diff)
 <pr_url>
+
+Daily note: added <N> comment(s) under <owner>/<repo>#<pr_number> in # Reviews (or "new PR entry" / "skipped — run /work:start first")
 ```
 
-Label each as `suggestion`, `inline`, or `general comment` so it's clear which are actionable.
+Label each finding as `suggestion`, `inline`, or `general comment` so it's clear which are actionable.

--- a/.claude/commands/work/start-day.md
+++ b/.claude/commands/work/start-day.md
@@ -51,6 +51,8 @@ ls "${notes_dir}/${today_file}.md" 2>/dev/null && echo "EXISTS" || echo "MISSING
   - `{{date:dddd}}` → today's day name (e.g., `Friday`)
   - `{{date:YYYY-MM-DD dddd}}` → today's full date with day (e.g., `2026-05-29 Friday`)
 
+The template includes a `# Reviews` section seeded with a `<!-- pr:post-findings appends reviewed PRs here -->` placeholder — this is where `/pr:post-findings` records reviewed PRs and the comments left on them. Leave it empty at startup. If today's note already **EXISTS** but predates this section (no `# Reviews` heading), insert one after the `# Work Items` block before continuing.
+
 **Important**: The template's yesterday link `[[{{date:YYYY-MM-DD dddd}}]]` will resolve to TODAY (self-reference). Step 3 fixes this.
 
 ## Step 3: Fix Yesterday Link

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,6 +4,7 @@
   "enabledPlugins": {
     "clangd-lsp@claude-plugins-official": true,
     "claude-code-setup@claude-plugins-official": true,
+    "claude-hud@claude-hud": true,
     "claude-md-management@claude-plugins-official": true,
     "code-review@claude-plugins-official": true,
     "compound-engineering@compound-engineering-plugin": true,

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -62,7 +62,7 @@ status_line_use_colors = true
 "gpt-5.5" = 4
 
 [marketplaces.openai-bundled]
-last_updated = "2026-07-07T11:12:21Z"
+last_updated = "2026-07-07T15:15:33Z"
 source_type = "local"
 source = "/Users/phatblat/.codex/.tmp/bundled-marketplaces/openai-bundled"
 
@@ -156,6 +156,9 @@ enabled = true
 enabled = false
 
 [plugins."linear-cli@linear-cli"]
+enabled = true
+
+[plugins."sites@openai-bundled"]
 enabled = true
 
 [mcp_servers.node_repl]

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -206,6 +206,7 @@ keepRemoteControlAwakeWhilePluggedIn = true
 codeFontSize = 14
 usePointerCursors = true
 composerEnterBehavior = "cmdIfMultiline"
+selected-avatar-id = "null-signal"
 
 [desktop.open-in-target-preferences]
 global = "zed"

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -207,6 +207,8 @@ codeFontSize = 14
 usePointerCursors = true
 composerEnterBehavior = "cmdIfMultiline"
 selected-avatar-id = "null-signal"
+dock-icon-preference = "codex-dark"
+git-pull-request-merge-method = "squash"
 
 [desktop.open-in-target-preferences]
 global = "zed"

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -72,13 +72,13 @@ source_type = "local"
 source = "/Users/phatblat/.cache/codex-runtimes/codex-primary-runtime/plugins/openai-primary-runtime"
 
 [marketplaces.claude-plugins-official]
-last_updated = "2026-07-07T15:00:35Z"
-last_revision = "7406dea99f3e6902a4b11ed57e698b7b5142de17"
+last_updated = "2026-07-07T20:05:11Z"
+last_revision = "6ec4b4020230e4c600407a1c46d76bc4f28a0d48"
 source_type = "git"
 source = "https://github.com/anthropics/claude-plugins-official.git"
 
 [marketplaces.compound-engineering-plugin]
-last_updated = "2026-07-07T02:22:42Z"
+last_updated = "2026-07-07T20:05:13Z"
 last_revision = "1287b0985ce6a6a2a0b35e2302df5658b171cc6d"
 source_type = "git"
 source = "https://github.com/EveryInc/compound-engineering-plugin.git"

--- a/.codexbar/config.json
+++ b/.codexbar/config.json
@@ -4,7 +4,7 @@
       "cookieSource": "auto",
       "enabled": true,
       "id": "claude",
-      "source": "auto"
+      "source": "oauth"
     },
     {
       "enabled": true,
@@ -213,6 +213,22 @@
     {
       "enabled": false,
       "id": "chutes"
+    },
+    {
+      "enabled": false,
+      "id": "sakana"
+    },
+    {
+      "enabled": false,
+      "id": "qoder"
+    },
+    {
+      "enabled": false,
+      "id": "crossmodel"
+    },
+    {
+      "enabled": false,
+      "id": "clawrouter"
     }
   ],
   "version": 1

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -19,7 +19,7 @@
 "cargo:wasm-pack" = "0.15.0"
 "github:cirruslabs/softnet" = "0.19.0"
 "github:dolthub/dolt" = "2.1.10"
-"github:harness/harness-cli" = "1.3.25"
+"github:harness/harness-cli" = "1.3.26"
 "github:nushell/nushell" = { version = "0.114.0", version_prefix = "" }
 "github:schpet/linear-cli" = "2.0.0"
 "go:golang.org/x/tools/gopls" = "0.22.0"

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -77,7 +77,7 @@ duf = "0.9.1"
 dust = "1.2.4"
 fastfetch = "2.65.2"
 fd = "10.4.2"
-fzf = "0.73.1"
+fzf = "0.74.0"
 gemini = { version = "0.49.0", allow_builds = ["@github/keytar", "node-pty"] }
 gh = "2.96.0"
 git-lfs = "3.7.1"

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -38,7 +38,7 @@
 "npm:markdownlint-cli2" = "0.23.0"
 "npm:pnpm" = "11.10.0"
 "npm:prettier" = "3.9.4"
-"npm:renovate" = "43.252.3"
+"npm:renovate" = "43.252.5"
 "npm:typescript" = "6.0.3"
 "npm:typescript-language-server" = "5.3.0"
 "npm:vscode-langservers-extracted" = "4.10.0"

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -124,7 +124,7 @@ sd = "1.1.0"
 shellcheck = "0.11.0"
 shfmt = "3.13.1"
 starship = "1.26.0"
-swiftformat = { version = "0.61.1", no_app = "true", rename_exe = "swiftformat" }
+swiftformat = { version = "0.62.0", rename_exe = "swiftformat", no_app = "true" }
 swiftlint = "0.65.0"
 terraform = "1.15.7"
 terraform-ls = "0.38.8"

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -30,7 +30,7 @@
 "npm:bash-language-server" = "5.6.0"
 "npm:ccusage" = "20.0.14"
 "npm:claudekit" = "0.9.5"
-"npm:ctx7" = "0.5.3"
+"npm:ctx7" = "0.5.4"
 "npm:gastown-gui" = "0.9.4"
 "npm:gtop" = "1.1.5"
 "npm:jsonlint" = "1.6.3"

--- a/.config/nushell/env.nu
+++ b/.config/nushell/env.nu
@@ -68,6 +68,9 @@ if ($_ndk_dir | path exists) {
     }
 }
 
+# Xcode DerivedData (consumed by the `ddd` command)
+$env.DERIVED_DATA = ($nu.home-dir | path join 'Library' 'Developer' 'Xcode' 'DerivedData')
+
 # Editor configuration
 $env.EDITOR = "zed"
 $env.VISUAL = "zed"

--- a/.gitignore
+++ b/.gitignore
@@ -737,6 +737,7 @@ Library/Application Support/rs.com.ditto.dql-browser/
 Library/Application Support/rs.snackos.gyro.staging/
 Library/Application Support/rtk/history.db
 Library/Application Support/rtk/tee/
+Library/Application Support/segment/
 Library/Application Support/summary-events/
 Library/Application Support/synergy/
 Library/Application Support/team.Immersed/

--- a/Library/Application Support/Claude/claude_desktop_config.json
+++ b/Library/Application Support/Claude/claude_desktop_config.json
@@ -47,6 +47,8 @@
       "starred-cowork-spaces": [],
       "starred-local-code-sessions": [],
       "starred-session-groups": []
-    }
+    },
+    "launchPreviewPersistedWorkspaces": [],
+    "launchPreviewSessionScopedSessions": []
   }
 }


### PR DESCRIPTION
## Summary

Daily dotfiles branch for 2026-07-06/07. The headline change vendors the full gstack skill suite directly into the repo, replacing a broken submodule reference so the skills work reliably across machines. The rest is routine upkeep: Codex and desktop app config updates, a few workflow command improvements, and scheduled tool version bumps.

## Changes

### gstack skills
- Vendor the gstack skill suite into `.claude/skills/`, replacing the broken submodule gitlink
- Add gstack usage guidance to `CLAUDE.md`
- Skip vendored gstack files in the `format-json` just recipe
- Ignore `.gstack/` and `.claude/skills/gstack/node_modules/`

### Codex & desktop config
- Switch Codex auth to OAuth and refresh disabled-tool configs
- Add dock icon preference and PR merge method settings
- Enable additional plugins; update plugin revisions and metadata
- Add Codex Homebrew cask; update avatar selection and desktop config files
- Trust the agentic-code-review project

### Workflow commands
- `pr:post-findings`: use `file:line` display text for comment links
- `work:start-day`: add the FORGE team to daily Linear queries
- Record reviewed PRs in the daily note under a `# Reviews` section

### Fixes
- `nushell`: export the `DERIVED_DATA` env var
- Install nushell via mise instead of a pinned version in lint CI

### Tool bumps
- swiftformat 0.61.1 → 0.62.0, fzf 0.73.1 → 0.74.0, cocoapods 1.16.2 → 1.17.0
- rust 1.96.0 → 1.96.1, uv 0.11.26 → 0.11.27, awscli 2.35.15 → 2.35.16
- mirrord 3.228.0 → 3.229.0, harness-cli 1.3.25 → 1.3.26, graphify 0.9.5 → 0.9.6
- ctx7 0.5.3 → 0.5.4, renovate 43.251.3 → 43.252.5