### PR TITLE
chore: friday 2026-07-31

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -4,7 +4,7 @@
 
 approvals_reviewer = "auto_review"
 commit_attribution = "Co-Authored-By: Codex <noreply@openai.com>"
-model = "gpt-5.6-sol"
+model = "gpt-5.6-luna"
 model_reasoning_effort = "xhigh"
 notify = ["/Users/phatblat/.codex/computer-use/Codex Computer Use.app/Contents/SharedSupport/SkyComputerUseClient.app/Contents/MacOS/SkyComputerUseClient", "turn-ended"]
 personality = "pragmatic"
@@ -33,6 +33,7 @@ localeOverride = "en-US"
 mac-menu-bar-enabled = false
 preventSleepWhileRunning = true
 selected-avatar-id = "null-signal"
+show-context-window-usage = true
 usePointerCursors = true
 
 [desktop.open-in-target-preferences]

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -62,13 +62,14 @@ cwd = "."
 enabled = false
 
 [mcp_servers.node_repl]
+args = []
 command = "/Applications/ChatGPT.app/Contents/Resources/cua_node/bin/node_repl"
-startup_timeout_sec = 120.0
+startup_timeout_sec = 120
 
 [mcp_servers.node_repl.env]
 BROWSER_USE_AVAILABLE_BACKENDS = "chrome,iab"
 BROWSER_USE_CODEX_APP_BUILD_FLAVOR = "prod"
-BROWSER_USE_CODEX_APP_VERSION = "26.721.81911"
+BROWSER_USE_CODEX_APP_VERSION = "26.727.51351"
 CODEX_CLI_PATH = "/Applications/ChatGPT.app/Contents/Resources/codex"
 CODEX_HOME = "/Users/phatblat/.codex"
 NODE_REPL_INSTRUCTIONS_USE_CASE_BROWSER = "Control the in-app browser in conjunction with the Browser Plugin."
@@ -77,7 +78,7 @@ NODE_REPL_INSTRUCTIONS_USE_CASE_COMPUTER_USE = "Control desktop apps on macOS th
 NODE_REPL_NATIVE_PIPE_CONNECT_TIMEOUT_MS = "1000"
 NODE_REPL_NODE_MODULE_DIRS = "/Applications/ChatGPT.app/Contents/Resources/cua_node/lib/node_modules"
 NODE_REPL_NODE_PATH = "/Applications/ChatGPT.app/Contents/Resources/cua_node/bin/node"
-NODE_REPL_TRUSTED_BROWSER_CLIENT_SHA256S = "14e425736668bf21b5b39f2cc022ee8684728617fb5c49f35533c2e349f47193,6d25aa7656feac858f3a3bdaea5bcbab0dbfd426c9de8e6931ce90c399ee8e4f"
+NODE_REPL_TRUSTED_BROWSER_CLIENT_SHA256S = "028a14b6eaa6d98dac2aae00764345ab9f244801ed8493d42b9af3be5575006e,f204d340535055781952b10ed396de20b842f00a19e430852f7e121ad1ce91f6"
 NODE_REPL_TRUSTED_CODE_PATHS = "/Users/phatblat/.codex"
 SKY_CUA_SERVICE_PATH = "/Users/phatblat/.codex/computer-use/Codex Computer Use.app"
 
@@ -111,7 +112,7 @@ BASH_DEFAULT_TIMEOUT_MS = "300000"
 BROWSER_USE_AVAILABLE_BACKENDS = "chrome,iab"
 CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1"
 MAX_MCP_OUTPUT_TOKENS = "25000"
-NODE_REPL_TRUSTED_BROWSER_CLIENT_SHA256S = "14e425736668bf21b5b39f2cc022ee8684728617fb5c49f35533c2e349f47193,6d25aa7656feac858f3a3bdaea5bcbab0dbfd426c9de8e6931ce90c399ee8e4f"
+NODE_REPL_TRUSTED_BROWSER_CLIENT_SHA256S = "028a14b6eaa6d98dac2aae00764345ab9f244801ed8493d42b9af3be5575006e,f204d340535055781952b10ed396de20b842f00a19e430852f7e121ad1ce91f6"
 NODE_REPL_TRUSTED_CODE_PATHS = "/Users/phatblat/.codex"
 
 [tui]

--- a/.config/fish/functions/pi-spark.fish
+++ b/.config/fish/functions/pi-spark.fish
@@ -1,0 +1,5 @@
+#!/usr/bin/env fish
+# Run Pi with the Spark Qwen model.
+function pi-spark
+    pi --provider spark --model nvidia/Qwen3.6-35B-A3B-NVFP4 $argv
+end

--- a/.config/nushell/autoload/pi-spark.nu
+++ b/.config/nushell/autoload/pi-spark.nu
@@ -1,0 +1,4 @@
+# Run Pi with the Spark Qwen model.
+export def --wrapped pi-spark [...args] {
+    ^pi --provider spark --model nvidia/Qwen3.6-35B-A3B-NVFP4 ...$args
+}

--- a/.config/zsh/functions/pi-spark
+++ b/.config/zsh/functions/pi-spark
@@ -1,0 +1,4 @@
+#!/usr/bin/env zsh
+
+# pi-spark - Run Pi with the Spark Qwen model
+pi --provider spark --model nvidia/Qwen3.6-35B-A3B-NVFP4 "$@"

--- a/.pi/agent/models-store.json
+++ b/.pi/agent/models-store.json
@@ -1,8 +1,8 @@
 {
   "openai-codex": {
-    "checkedAt": 1785374208618,
-    "etag": "W/\"8c50b40966720784303e46378a0807dc\"",
-    "lastModified": 1785243514000,
+    "checkedAt": 1785616276513,
+    "etag": "W/\"400cac2d73673d9fff4c7d0ed22691b0\"",
+    "lastModified": 1785502727000,
     "models": [
       {
         "api": "openai-codex-responses",
@@ -141,17 +141,17 @@
         },
         "contextWindow": 272000,
         "cost": {
-          "cacheRead": 0.1,
-          "cacheWrite": 1.25,
-          "input": 1,
-          "output": 6,
+          "cacheRead": 0.02,
+          "cacheWrite": 0.25,
+          "input": 0.2,
+          "output": 1.2,
           "tiers": [
             {
-              "cacheRead": 0.2,
-              "cacheWrite": 2.5,
-              "input": 2,
+              "cacheRead": 0.04,
+              "cacheWrite": 0.5,
+              "input": 0.4,
               "inputTokensAbove": 272000,
-              "output": 9
+              "output": 1.8
             }
           ]
         },
@@ -217,17 +217,17 @@
         },
         "contextWindow": 272000,
         "cost": {
-          "cacheRead": 0.25,
-          "cacheWrite": 3.125,
-          "input": 2.5,
-          "output": 15,
+          "cacheRead": 0.2,
+          "cacheWrite": 2.5,
+          "input": 2,
+          "output": 12,
           "tiers": [
             {
-              "cacheRead": 0.5,
-              "cacheWrite": 6.25,
-              "input": 5,
+              "cacheRead": 0.4,
+              "cacheWrite": 5,
+              "input": 4,
               "inputTokensAbove": 272000,
-              "output": 22.5
+              "output": 18
             }
           ]
         },

--- a/.pi/agent/models-store.json
+++ b/.pi/agent/models-store.json
@@ -1,6 +1,6 @@
 {
   "openai-codex": {
-    "checkedAt": 1785616276513,
+    "checkedAt": 1785617155918,
     "etag": "W/\"400cac2d73673d9fff4c7d0ed22691b0\"",
     "lastModified": 1785502727000,
     "models": [

--- a/tests/pi-functions.bats
+++ b/tests/pi-functions.bats
@@ -79,3 +79,34 @@ teardown() {
   [ "$status" -eq 0 ]
   [ "$output" = $'--resume\n--name\nresume session' ]
 }
+
+@test "zsh pi-spark runs Pi with the Spark Qwen model" {
+  run env PATH="$fakebindir:$PATH" zsh -c '
+    fpath=("$HOME/.config/zsh/functions" $fpath)
+    autoload -Uz pi-spark
+    pi-spark
+  '
+
+  [ "$status" -eq 0 ]
+  [ "$output" = $'--provider\nspark\n--model\nnvidia/Qwen3.6-35B-A3B-NVFP4' ]
+}
+
+@test "fish pi-spark runs Pi with the Spark Qwen model" {
+  run env PATH="$fakebindir:$PATH" fish --no-config -c '
+    source "$HOME/.config/fish/functions/pi-spark.fish"
+    pi-spark
+  '
+
+  [ "$status" -eq 0 ]
+  [ "$output" = $'--provider\nspark\n--model\nnvidia/Qwen3.6-35B-A3B-NVFP4' ]
+}
+
+@test "nushell pi-spark runs Pi with the Spark Qwen model" {
+  run env PATH="$fakebindir:$PATH" nu --no-config-file -c "
+    source '$HOME/.config/nushell/autoload/pi-spark.nu'
+    pi-spark
+  "
+
+  [ "$status" -eq 0 ]
+  [ "$output" = $'--provider\nspark\n--model\nnvidia/Qwen3.6-35B-A3B-NVFP4' ]
+}


### PR DESCRIPTION
## Summary
Keep local development and agent tooling current while adding access to a local AI service and a reusable handoff workflow. Make command lookup behave consistently across supported shells.

## Changes
- Add Spark as a local Pi model provider and provide shell launchers for it.
- Add a handoff skill and generate adapters for supported agent tools.
- Standardize shell path setup so locally installed commands take precedence consistently.
- Refresh agent model and provider catalogs, pricing, and Codex integration settings.
- Update pinned development tools and ignore local application data directories.
- Add coverage for shell paths, Pi functions, and generated agent-harness adapters.