### PR TITLE
feat(harness): Harden the control plane before automating changes

### DIFF
--- a/.agents/harness/generated-paths.json
+++ b/.agents/harness/generated-paths.json
@@ -1,0 +1,824 @@
+{
+  "~/.agents/harness/README.md": {
+    "source": ""
+  },
+  "~/.agents/harness/adapters/antigravity/agents/ai-sdk-expert.md": {
+    "source": "~/.codex/agents/ai-sdk-expert.toml"
+  },
+  "~/.agents/harness/adapters/antigravity/agents/cli-expert.md": {
+    "source": "~/.codex/agents/cli-expert.toml"
+  },
+  "~/.agents/harness/adapters/antigravity/agents/code-review-expert.md": {
+    "source": "~/.codex/agents/code-review-expert.toml"
+  },
+  "~/.agents/harness/adapters/antigravity/agents/nestjs-expert.md": {
+    "source": "~/.codex/agents/nestjs-expert.toml"
+  },
+  "~/.agents/harness/adapters/antigravity/agents/research-expert.md": {
+    "source": "~/.codex/agents/research-expert.toml"
+  },
+  "~/.agents/harness/adapters/antigravity/agents/triage-expert.md": {
+    "source": "~/.codex/agents/triage-expert.toml"
+  },
+  "~/.agents/harness/adapters/antigravity/commands/dupe.md": {
+    "source": "~/.claude/commands/dupe.md"
+  },
+  "~/.agents/harness/adapters/antigravity/commands/git/cleanup.md": {
+    "source": "~/.claude/commands/git/cleanup.md"
+  },
+  "~/.agents/harness/adapters/antigravity/commands/git/commit.md": {
+    "source": "~/.claude/commands/git/commit.md"
+  },
+  "~/.agents/harness/adapters/antigravity/commands/git/push.md": {
+    "source": "~/.claude/commands/git/push.md"
+  },
+  "~/.agents/harness/adapters/antigravity/commands/git/rebase.md": {
+    "source": "~/.claude/commands/git/rebase.md"
+  },
+  "~/.agents/harness/adapters/antigravity/commands/git/split.md": {
+    "source": "~/.claude/commands/git/split.md"
+  },
+  "~/.agents/harness/adapters/antigravity/commands/git/status.md": {
+    "source": "~/.claude/commands/git/status.md"
+  },
+  "~/.agents/harness/adapters/antigravity/commands/linear/plan.md": {
+    "source": "~/.claude/commands/linear/plan.md"
+  },
+  "~/.agents/harness/adapters/antigravity/commands/linear/progress.md": {
+    "source": "~/.claude/commands/linear/progress.md"
+  },
+  "~/.agents/harness/adapters/antigravity/commands/optimize.md": {
+    "source": "~/.claude/commands/optimize.md"
+  },
+  "~/.agents/harness/adapters/antigravity/commands/pr/approve.md": {
+    "source": "~/.claude/commands/pr/approve.md"
+  },
+  "~/.agents/harness/adapters/antigravity/commands/pr/create.md": {
+    "source": "~/.claude/commands/pr/create.md"
+  },
+  "~/.agents/harness/adapters/antigravity/commands/pr/daily.md": {
+    "source": "~/.claude/commands/pr/daily.md"
+  },
+  "~/.agents/harness/adapters/antigravity/commands/pr/merge.md": {
+    "source": "~/.claude/commands/pr/merge.md"
+  },
+  "~/.agents/harness/adapters/antigravity/commands/pr/open-for-review.md": {
+    "source": "~/.claude/commands/pr/open-for-review.md"
+  },
+  "~/.agents/harness/adapters/antigravity/commands/pr/post-findings.md": {
+    "source": "~/.claude/commands/pr/post-findings.md"
+  },
+  "~/.agents/harness/adapters/antigravity/commands/pr/resolve-feedback.md": {
+    "source": "~/.claude/commands/pr/resolve-feedback.md"
+  },
+  "~/.agents/harness/adapters/antigravity/commands/pr/update-desc.md": {
+    "source": "~/.claude/commands/pr/update-desc.md"
+  },
+  "~/.agents/harness/adapters/antigravity/commands/retro.md": {
+    "source": "~/.claude/commands/retro.md"
+  },
+  "~/.agents/harness/adapters/antigravity/commands/session-save.md": {
+    "source": "~/.claude/commands/session-save.md"
+  },
+  "~/.agents/harness/adapters/antigravity/commands/work/eod.md": {
+    "source": "~/.claude/commands/work/eod.md"
+  },
+  "~/.agents/harness/adapters/antigravity/commands/work/runners.md": {
+    "source": "~/.claude/commands/work/runners.md"
+  },
+  "~/.agents/harness/adapters/antigravity/commands/work/start-day.md": {
+    "source": "~/.claude/commands/work/start-day.md"
+  },
+  "~/.agents/harness/adapters/antigravity/commands/work/track-item.md": {
+    "source": "~/.claude/commands/work/track-item.md"
+  },
+  "~/.agents/harness/adapters/antigravity/hooks/hooks.json": {
+    "source": ""
+  },
+  "~/.agents/harness/adapters/antigravity/mcp.json": {
+    "source": ""
+  },
+  "~/.agents/harness/adapters/antigravity/plugin.json": {
+    "source": ""
+  },
+  "~/.agents/harness/adapters/antigravity/scripts/harness-guard.py": {
+    "source": ""
+  },
+  "~/.agents/harness/adapters/antigravity/skills/aven/SKILL.md": {
+    "source": "~/.agents/skills/aven/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/boris/SKILL.md": {
+    "source": "~/.agents/skills/boris/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/brainstorm/SKILL.md": {
+    "source": "~/.agents/skills/brainstorm/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/branch-finish/SKILL.md": {
+    "source": "~/.agents/skills/branch-finish/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/debug-issue/SKILL.md": {
+    "source": "~/.agents/skills/debug-issue/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/dispatching-parallel-agents/SKILL.md": {
+    "source": "~/.agents/skills/dispatching-parallel-agents/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/dupe/SKILL.md": {
+    "source": "~/.agents/skills/dupe/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/executing-plans/SKILL.md": {
+    "source": "~/.agents/skills/executing-plans/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/find-docs/SKILL.md": {
+    "source": "~/.agents/skills/find-docs/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/find-skills/SKILL.md": {
+    "source": "~/.agents/skills/find-skills/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/gh-stack/SKILL.md": {
+    "source": "~/.agents/skills/gh-stack/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/gha-checks/SKILL.md": {
+    "source": "~/.agents/skills/gha-checks/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/gha-log-reader/SKILL.md": {
+    "source": "~/.agents/skills/gha-log-reader/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/git-cleanup/SKILL.md": {
+    "source": "~/.agents/skills/git-cleanup/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/git-commit/SKILL.md": {
+    "source": "~/.agents/skills/git-commit/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/git-push/SKILL.md": {
+    "source": "~/.agents/skills/git-push/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/git-rebase/SKILL.md": {
+    "source": "~/.agents/skills/git-rebase/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/git-split/SKILL.md": {
+    "source": "~/.agents/skills/git-split/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/git-status/SKILL.md": {
+    "source": "~/.agents/skills/git-status/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/git-worktrees/SKILL.md": {
+    "source": "~/.agents/skills/git-worktrees/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/graphify/SKILL.md": {
+    "source": "~/.agents/skills/graphify/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/handoff/SKILL.md": {
+    "source": "~/.agents/skills/handoff/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/linear-plan/SKILL.md": {
+    "source": "~/.agents/skills/linear-plan/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/ocr/SKILL.md": {
+    "source": "~/.agents/skills/ocr/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/optimize/SKILL.md": {
+    "source": "~/.agents/skills/optimize/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/pr-approve/SKILL.md": {
+    "source": "~/.agents/skills/pr-approve/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/pr-create/SKILL.md": {
+    "source": "~/.agents/skills/pr-create/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/pr-daily/SKILL.md": {
+    "source": "~/.agents/skills/pr-daily/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/pr-merge/SKILL.md": {
+    "source": "~/.agents/skills/pr-merge/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/pr-open-for-review/SKILL.md": {
+    "source": "~/.agents/skills/pr-open-for-review/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/pr-post-findings/SKILL.md": {
+    "source": "~/.agents/skills/pr-post-findings/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/pr-resolve-feedback/SKILL.md": {
+    "source": "~/.agents/skills/pr-resolve-feedback/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/pr-style/SKILL.md": {
+    "source": "~/.agents/skills/pr-style/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/pr-update-desc/SKILL.md": {
+    "source": "~/.agents/skills/pr-update-desc/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/receiving-code-review/SKILL.md": {
+    "source": "~/.agents/skills/receiving-code-review/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/refactor-safely/SKILL.md": {
+    "source": "~/.agents/skills/refactor-safely/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/requesting-code-review/SKILL.md": {
+    "source": "~/.agents/skills/requesting-code-review/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/resolve-feedback/SKILL.md": {
+    "source": "~/.agents/skills/resolve-feedback/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/retro/SKILL.md": {
+    "source": "~/.agents/skills/retro/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/review-changes/SKILL.md": {
+    "source": "~/.agents/skills/review-changes/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/session-save/SKILL.md": {
+    "source": "~/.agents/skills/session-save/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/subagent-driven-development/SKILL.md": {
+    "source": "~/.agents/skills/subagent-driven-development/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/test-driven-development/SKILL.md": {
+    "source": "~/.agents/skills/test-driven-development/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/work-eod/SKILL.md": {
+    "source": "~/.agents/skills/work-eod/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/work-runners/SKILL.md": {
+    "source": "~/.agents/skills/work-runners/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/work-start/SKILL.md": {
+    "source": "~/.agents/skills/work-start/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/work-track/SKILL.md": {
+    "source": "~/.agents/skills/work-track/SKILL.md"
+  },
+  "~/.agents/harness/adapters/antigravity/skills/writing-plans/SKILL.md": {
+    "source": "~/.agents/skills/writing-plans/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/.cursor-plugin/plugin.json": {
+    "source": ""
+  },
+  "~/.agents/harness/adapters/cursor/agents/ai-sdk-expert.md": {
+    "source": "~/.codex/agents/ai-sdk-expert.toml"
+  },
+  "~/.agents/harness/adapters/cursor/agents/cli-expert.md": {
+    "source": "~/.codex/agents/cli-expert.toml"
+  },
+  "~/.agents/harness/adapters/cursor/agents/code-review-expert.md": {
+    "source": "~/.codex/agents/code-review-expert.toml"
+  },
+  "~/.agents/harness/adapters/cursor/agents/nestjs-expert.md": {
+    "source": "~/.codex/agents/nestjs-expert.toml"
+  },
+  "~/.agents/harness/adapters/cursor/agents/research-expert.md": {
+    "source": "~/.codex/agents/research-expert.toml"
+  },
+  "~/.agents/harness/adapters/cursor/agents/triage-expert.md": {
+    "source": "~/.codex/agents/triage-expert.toml"
+  },
+  "~/.agents/harness/adapters/cursor/commands/dupe.md": {
+    "source": "~/.claude/commands/dupe.md"
+  },
+  "~/.agents/harness/adapters/cursor/commands/git/cleanup.md": {
+    "source": "~/.claude/commands/git/cleanup.md"
+  },
+  "~/.agents/harness/adapters/cursor/commands/git/commit.md": {
+    "source": "~/.claude/commands/git/commit.md"
+  },
+  "~/.agents/harness/adapters/cursor/commands/git/push.md": {
+    "source": "~/.claude/commands/git/push.md"
+  },
+  "~/.agents/harness/adapters/cursor/commands/git/rebase.md": {
+    "source": "~/.claude/commands/git/rebase.md"
+  },
+  "~/.agents/harness/adapters/cursor/commands/git/split.md": {
+    "source": "~/.claude/commands/git/split.md"
+  },
+  "~/.agents/harness/adapters/cursor/commands/git/status.md": {
+    "source": "~/.claude/commands/git/status.md"
+  },
+  "~/.agents/harness/adapters/cursor/commands/linear/plan.md": {
+    "source": "~/.claude/commands/linear/plan.md"
+  },
+  "~/.agents/harness/adapters/cursor/commands/linear/progress.md": {
+    "source": "~/.claude/commands/linear/progress.md"
+  },
+  "~/.agents/harness/adapters/cursor/commands/optimize.md": {
+    "source": "~/.claude/commands/optimize.md"
+  },
+  "~/.agents/harness/adapters/cursor/commands/pr/approve.md": {
+    "source": "~/.claude/commands/pr/approve.md"
+  },
+  "~/.agents/harness/adapters/cursor/commands/pr/create.md": {
+    "source": "~/.claude/commands/pr/create.md"
+  },
+  "~/.agents/harness/adapters/cursor/commands/pr/daily.md": {
+    "source": "~/.claude/commands/pr/daily.md"
+  },
+  "~/.agents/harness/adapters/cursor/commands/pr/merge.md": {
+    "source": "~/.claude/commands/pr/merge.md"
+  },
+  "~/.agents/harness/adapters/cursor/commands/pr/open-for-review.md": {
+    "source": "~/.claude/commands/pr/open-for-review.md"
+  },
+  "~/.agents/harness/adapters/cursor/commands/pr/post-findings.md": {
+    "source": "~/.claude/commands/pr/post-findings.md"
+  },
+  "~/.agents/harness/adapters/cursor/commands/pr/resolve-feedback.md": {
+    "source": "~/.claude/commands/pr/resolve-feedback.md"
+  },
+  "~/.agents/harness/adapters/cursor/commands/pr/update-desc.md": {
+    "source": "~/.claude/commands/pr/update-desc.md"
+  },
+  "~/.agents/harness/adapters/cursor/commands/retro.md": {
+    "source": "~/.claude/commands/retro.md"
+  },
+  "~/.agents/harness/adapters/cursor/commands/session-save.md": {
+    "source": "~/.claude/commands/session-save.md"
+  },
+  "~/.agents/harness/adapters/cursor/commands/work/eod.md": {
+    "source": "~/.claude/commands/work/eod.md"
+  },
+  "~/.agents/harness/adapters/cursor/commands/work/runners.md": {
+    "source": "~/.claude/commands/work/runners.md"
+  },
+  "~/.agents/harness/adapters/cursor/commands/work/start-day.md": {
+    "source": "~/.claude/commands/work/start-day.md"
+  },
+  "~/.agents/harness/adapters/cursor/commands/work/track-item.md": {
+    "source": "~/.claude/commands/work/track-item.md"
+  },
+  "~/.agents/harness/adapters/cursor/hooks/hooks.json": {
+    "source": ""
+  },
+  "~/.agents/harness/adapters/cursor/mcp.json": {
+    "source": ""
+  },
+  "~/.agents/harness/adapters/cursor/rules/shared-harness.mdc": {
+    "source": ""
+  },
+  "~/.agents/harness/adapters/cursor/scripts/harness-guard.py": {
+    "source": ""
+  },
+  "~/.agents/harness/adapters/cursor/skills/aven/SKILL.md": {
+    "source": "~/.agents/skills/aven/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/boris/SKILL.md": {
+    "source": "~/.agents/skills/boris/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/brainstorm/SKILL.md": {
+    "source": "~/.agents/skills/brainstorm/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/branch-finish/SKILL.md": {
+    "source": "~/.agents/skills/branch-finish/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/debug-issue/SKILL.md": {
+    "source": "~/.agents/skills/debug-issue/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/dispatching-parallel-agents/SKILL.md": {
+    "source": "~/.agents/skills/dispatching-parallel-agents/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/dupe/SKILL.md": {
+    "source": "~/.agents/skills/dupe/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/executing-plans/SKILL.md": {
+    "source": "~/.agents/skills/executing-plans/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/find-docs/SKILL.md": {
+    "source": "~/.agents/skills/find-docs/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/find-skills/SKILL.md": {
+    "source": "~/.agents/skills/find-skills/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/gh-stack/SKILL.md": {
+    "source": "~/.agents/skills/gh-stack/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/gha-checks/SKILL.md": {
+    "source": "~/.agents/skills/gha-checks/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/gha-log-reader/SKILL.md": {
+    "source": "~/.agents/skills/gha-log-reader/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/git-cleanup/SKILL.md": {
+    "source": "~/.agents/skills/git-cleanup/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/git-commit/SKILL.md": {
+    "source": "~/.agents/skills/git-commit/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/git-push/SKILL.md": {
+    "source": "~/.agents/skills/git-push/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/git-rebase/SKILL.md": {
+    "source": "~/.agents/skills/git-rebase/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/git-split/SKILL.md": {
+    "source": "~/.agents/skills/git-split/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/git-status/SKILL.md": {
+    "source": "~/.agents/skills/git-status/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/git-worktrees/SKILL.md": {
+    "source": "~/.agents/skills/git-worktrees/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/graphify/SKILL.md": {
+    "source": "~/.agents/skills/graphify/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/handoff/SKILL.md": {
+    "source": "~/.agents/skills/handoff/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/linear-plan/SKILL.md": {
+    "source": "~/.agents/skills/linear-plan/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/ocr/SKILL.md": {
+    "source": "~/.agents/skills/ocr/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/optimize/SKILL.md": {
+    "source": "~/.agents/skills/optimize/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/pr-approve/SKILL.md": {
+    "source": "~/.agents/skills/pr-approve/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/pr-create/SKILL.md": {
+    "source": "~/.agents/skills/pr-create/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/pr-daily/SKILL.md": {
+    "source": "~/.agents/skills/pr-daily/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/pr-merge/SKILL.md": {
+    "source": "~/.agents/skills/pr-merge/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/pr-open-for-review/SKILL.md": {
+    "source": "~/.agents/skills/pr-open-for-review/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/pr-post-findings/SKILL.md": {
+    "source": "~/.agents/skills/pr-post-findings/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/pr-resolve-feedback/SKILL.md": {
+    "source": "~/.agents/skills/pr-resolve-feedback/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/pr-style/SKILL.md": {
+    "source": "~/.agents/skills/pr-style/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/pr-update-desc/SKILL.md": {
+    "source": "~/.agents/skills/pr-update-desc/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/receiving-code-review/SKILL.md": {
+    "source": "~/.agents/skills/receiving-code-review/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/refactor-safely/SKILL.md": {
+    "source": "~/.agents/skills/refactor-safely/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/requesting-code-review/SKILL.md": {
+    "source": "~/.agents/skills/requesting-code-review/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/resolve-feedback/SKILL.md": {
+    "source": "~/.agents/skills/resolve-feedback/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/retro/SKILL.md": {
+    "source": "~/.agents/skills/retro/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/review-changes/SKILL.md": {
+    "source": "~/.agents/skills/review-changes/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/session-save/SKILL.md": {
+    "source": "~/.agents/skills/session-save/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/subagent-driven-development/SKILL.md": {
+    "source": "~/.agents/skills/subagent-driven-development/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/test-driven-development/SKILL.md": {
+    "source": "~/.agents/skills/test-driven-development/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/work-eod/SKILL.md": {
+    "source": "~/.agents/skills/work-eod/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/work-runners/SKILL.md": {
+    "source": "~/.agents/skills/work-runners/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/work-start/SKILL.md": {
+    "source": "~/.agents/skills/work-start/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/work-track/SKILL.md": {
+    "source": "~/.agents/skills/work-track/SKILL.md"
+  },
+  "~/.agents/harness/adapters/cursor/skills/writing-plans/SKILL.md": {
+    "source": "~/.agents/skills/writing-plans/SKILL.md"
+  },
+  "~/.agents/harness/agents/ai-sdk-expert.toml": {
+    "source": "~/.codex/agents/ai-sdk-expert.toml"
+  },
+  "~/.agents/harness/agents/cli-expert.toml": {
+    "source": "~/.codex/agents/cli-expert.toml"
+  },
+  "~/.agents/harness/agents/code-review-expert.toml": {
+    "source": "~/.codex/agents/code-review-expert.toml"
+  },
+  "~/.agents/harness/agents/nestjs-expert.toml": {
+    "source": "~/.codex/agents/nestjs-expert.toml"
+  },
+  "~/.agents/harness/agents/research-expert.toml": {
+    "source": "~/.codex/agents/research-expert.toml"
+  },
+  "~/.agents/harness/agents/triage-expert.toml": {
+    "source": "~/.codex/agents/triage-expert.toml"
+  },
+  "~/.agents/harness/commands/dupe.md": {
+    "source": "~/.claude/commands/dupe.md"
+  },
+  "~/.agents/harness/commands/git/cleanup.md": {
+    "source": "~/.claude/commands/git/cleanup.md"
+  },
+  "~/.agents/harness/commands/git/commit.md": {
+    "source": "~/.claude/commands/git/commit.md"
+  },
+  "~/.agents/harness/commands/git/push.md": {
+    "source": "~/.claude/commands/git/push.md"
+  },
+  "~/.agents/harness/commands/git/rebase.md": {
+    "source": "~/.claude/commands/git/rebase.md"
+  },
+  "~/.agents/harness/commands/git/split.md": {
+    "source": "~/.claude/commands/git/split.md"
+  },
+  "~/.agents/harness/commands/git/status.md": {
+    "source": "~/.claude/commands/git/status.md"
+  },
+  "~/.agents/harness/commands/linear/plan.md": {
+    "source": "~/.claude/commands/linear/plan.md"
+  },
+  "~/.agents/harness/commands/linear/progress.md": {
+    "source": "~/.claude/commands/linear/progress.md"
+  },
+  "~/.agents/harness/commands/optimize.md": {
+    "source": "~/.claude/commands/optimize.md"
+  },
+  "~/.agents/harness/commands/pr/approve.md": {
+    "source": "~/.claude/commands/pr/approve.md"
+  },
+  "~/.agents/harness/commands/pr/create.md": {
+    "source": "~/.claude/commands/pr/create.md"
+  },
+  "~/.agents/harness/commands/pr/daily.md": {
+    "source": "~/.claude/commands/pr/daily.md"
+  },
+  "~/.agents/harness/commands/pr/merge.md": {
+    "source": "~/.claude/commands/pr/merge.md"
+  },
+  "~/.agents/harness/commands/pr/open-for-review.md": {
+    "source": "~/.claude/commands/pr/open-for-review.md"
+  },
+  "~/.agents/harness/commands/pr/post-findings.md": {
+    "source": "~/.claude/commands/pr/post-findings.md"
+  },
+  "~/.agents/harness/commands/pr/resolve-feedback.md": {
+    "source": "~/.claude/commands/pr/resolve-feedback.md"
+  },
+  "~/.agents/harness/commands/pr/update-desc.md": {
+    "source": "~/.claude/commands/pr/update-desc.md"
+  },
+  "~/.agents/harness/commands/retro.md": {
+    "source": "~/.claude/commands/retro.md"
+  },
+  "~/.agents/harness/commands/session-save.md": {
+    "source": "~/.claude/commands/session-save.md"
+  },
+  "~/.agents/harness/commands/work/eod.md": {
+    "source": "~/.claude/commands/work/eod.md"
+  },
+  "~/.agents/harness/commands/work/runners.md": {
+    "source": "~/.claude/commands/work/runners.md"
+  },
+  "~/.agents/harness/commands/work/start-day.md": {
+    "source": "~/.claude/commands/work/start-day.md"
+  },
+  "~/.agents/harness/commands/work/track-item.md": {
+    "source": "~/.claude/commands/work/track-item.md"
+  },
+  "~/.agents/harness/generated-paths.json": {
+    "source": ""
+  },
+  "~/.agents/harness/hooks/contract.json": {
+    "source": ""
+  },
+  "~/.agents/harness/hooks/safety-policy.json": {
+    "source": ""
+  },
+  "~/.agents/harness/instructions.md": {
+    "source": ""
+  },
+  "~/.claude/skills/aven/SKILL.md": {
+    "source": "~/.agents/skills/aven/SKILL.md"
+  },
+  "~/.claude/skills/handoff/SKILL.md": {
+    "source": "~/.agents/skills/handoff/SKILL.md"
+  },
+  "~/.codex/skills/aven/SKILL.md": {
+    "source": "~/.agents/skills/aven/SKILL.md"
+  },
+  "~/.codex/skills/handoff/SKILL.md": {
+    "source": "~/.agents/skills/handoff/SKILL.md"
+  },
+  "~/.codex/skills/handoff/agents/openai.yaml": {
+    "source": "~/.agents/skills/handoff/SKILL.md"
+  },
+  "~/.config/opencode/agents/ai-sdk-expert.md": {
+    "source": "~/.codex/agents/ai-sdk-expert.toml"
+  },
+  "~/.config/opencode/agents/cli-expert.md": {
+    "source": "~/.codex/agents/cli-expert.toml"
+  },
+  "~/.config/opencode/agents/code-review-expert.md": {
+    "source": "~/.codex/agents/code-review-expert.toml"
+  },
+  "~/.config/opencode/agents/nestjs-expert.md": {
+    "source": "~/.codex/agents/nestjs-expert.toml"
+  },
+  "~/.config/opencode/agents/research-expert.md": {
+    "source": "~/.codex/agents/research-expert.toml"
+  },
+  "~/.config/opencode/agents/triage-expert.md": {
+    "source": "~/.codex/agents/triage-expert.toml"
+  },
+  "~/.config/opencode/commands/dupe.md": {
+    "source": "~/.claude/commands/dupe.md"
+  },
+  "~/.config/opencode/commands/git:cleanup.md": {
+    "source": "~/.claude/commands/git/cleanup.md"
+  },
+  "~/.config/opencode/commands/git:commit.md": {
+    "source": "~/.claude/commands/git/commit.md"
+  },
+  "~/.config/opencode/commands/git:push.md": {
+    "source": "~/.claude/commands/git/push.md"
+  },
+  "~/.config/opencode/commands/git:rebase.md": {
+    "source": "~/.claude/commands/git/rebase.md"
+  },
+  "~/.config/opencode/commands/git:split.md": {
+    "source": "~/.claude/commands/git/split.md"
+  },
+  "~/.config/opencode/commands/git:status.md": {
+    "source": "~/.claude/commands/git/status.md"
+  },
+  "~/.config/opencode/commands/linear:plan.md": {
+    "source": "~/.claude/commands/linear/plan.md"
+  },
+  "~/.config/opencode/commands/linear:progress.md": {
+    "source": "~/.claude/commands/linear/progress.md"
+  },
+  "~/.config/opencode/commands/optimize.md": {
+    "source": "~/.claude/commands/optimize.md"
+  },
+  "~/.config/opencode/commands/pr:approve.md": {
+    "source": "~/.claude/commands/pr/approve.md"
+  },
+  "~/.config/opencode/commands/pr:create.md": {
+    "source": "~/.claude/commands/pr/create.md"
+  },
+  "~/.config/opencode/commands/pr:daily.md": {
+    "source": "~/.claude/commands/pr/daily.md"
+  },
+  "~/.config/opencode/commands/pr:merge.md": {
+    "source": "~/.claude/commands/pr/merge.md"
+  },
+  "~/.config/opencode/commands/pr:open-for-review.md": {
+    "source": "~/.claude/commands/pr/open-for-review.md"
+  },
+  "~/.config/opencode/commands/pr:post-findings.md": {
+    "source": "~/.claude/commands/pr/post-findings.md"
+  },
+  "~/.config/opencode/commands/pr:resolve-feedback.md": {
+    "source": "~/.claude/commands/pr/resolve-feedback.md"
+  },
+  "~/.config/opencode/commands/pr:update-desc.md": {
+    "source": "~/.claude/commands/pr/update-desc.md"
+  },
+  "~/.config/opencode/commands/retro.md": {
+    "source": "~/.claude/commands/retro.md"
+  },
+  "~/.config/opencode/commands/session-save.md": {
+    "source": "~/.claude/commands/session-save.md"
+  },
+  "~/.config/opencode/commands/work:eod.md": {
+    "source": "~/.claude/commands/work/eod.md"
+  },
+  "~/.config/opencode/commands/work:runners.md": {
+    "source": "~/.claude/commands/work/runners.md"
+  },
+  "~/.config/opencode/commands/work:start-day.md": {
+    "source": "~/.claude/commands/work/start-day.md"
+  },
+  "~/.config/opencode/commands/work:track-item.md": {
+    "source": "~/.claude/commands/work/track-item.md"
+  },
+  "~/.config/opencode/opencode.jsonc": {
+    "source": ""
+  },
+  "~/.config/opencode/plugins/harness.ts": {
+    "source": ""
+  },
+  "~/.config/opencode/skills/aven/SKILL.md": {
+    "source": "~/.agents/skills/aven/SKILL.md"
+  },
+  "~/.config/opencode/skills/handoff/SKILL.md": {
+    "source": "~/.agents/skills/handoff/SKILL.md"
+  },
+  "~/.pi/agent/agents.json": {
+    "source": ""
+  },
+  "~/.pi/agent/agents/ai-sdk-expert.md": {
+    "source": "~/.codex/agents/ai-sdk-expert.toml"
+  },
+  "~/.pi/agent/agents/cli-expert.md": {
+    "source": "~/.codex/agents/cli-expert.toml"
+  },
+  "~/.pi/agent/agents/code-review-expert.md": {
+    "source": "~/.codex/agents/code-review-expert.toml"
+  },
+  "~/.pi/agent/agents/nestjs-expert.md": {
+    "source": "~/.codex/agents/nestjs-expert.toml"
+  },
+  "~/.pi/agent/agents/research-expert.md": {
+    "source": "~/.codex/agents/research-expert.toml"
+  },
+  "~/.pi/agent/agents/triage-expert.md": {
+    "source": "~/.codex/agents/triage-expert.toml"
+  },
+  "~/.pi/agent/extensions/harness.ts": {
+    "source": ""
+  },
+  "~/.pi/agent/prompts/dupe.md": {
+    "source": "~/.claude/commands/dupe.md"
+  },
+  "~/.pi/agent/prompts/git:cleanup.md": {
+    "source": "~/.claude/commands/git/cleanup.md"
+  },
+  "~/.pi/agent/prompts/git:commit.md": {
+    "source": "~/.claude/commands/git/commit.md"
+  },
+  "~/.pi/agent/prompts/git:push.md": {
+    "source": "~/.claude/commands/git/push.md"
+  },
+  "~/.pi/agent/prompts/git:rebase.md": {
+    "source": "~/.claude/commands/git/rebase.md"
+  },
+  "~/.pi/agent/prompts/git:split.md": {
+    "source": "~/.claude/commands/git/split.md"
+  },
+  "~/.pi/agent/prompts/git:status.md": {
+    "source": "~/.claude/commands/git/status.md"
+  },
+  "~/.pi/agent/prompts/linear:plan.md": {
+    "source": "~/.claude/commands/linear/plan.md"
+  },
+  "~/.pi/agent/prompts/linear:progress.md": {
+    "source": "~/.claude/commands/linear/progress.md"
+  },
+  "~/.pi/agent/prompts/optimize.md": {
+    "source": "~/.claude/commands/optimize.md"
+  },
+  "~/.pi/agent/prompts/pr:approve.md": {
+    "source": "~/.claude/commands/pr/approve.md"
+  },
+  "~/.pi/agent/prompts/pr:create.md": {
+    "source": "~/.claude/commands/pr/create.md"
+  },
+  "~/.pi/agent/prompts/pr:daily.md": {
+    "source": "~/.claude/commands/pr/daily.md"
+  },
+  "~/.pi/agent/prompts/pr:merge.md": {
+    "source": "~/.claude/commands/pr/merge.md"
+  },
+  "~/.pi/agent/prompts/pr:open-for-review.md": {
+    "source": "~/.claude/commands/pr/open-for-review.md"
+  },
+  "~/.pi/agent/prompts/pr:post-findings.md": {
+    "source": "~/.claude/commands/pr/post-findings.md"
+  },
+  "~/.pi/agent/prompts/pr:resolve-feedback.md": {
+    "source": "~/.claude/commands/pr/resolve-feedback.md"
+  },
+  "~/.pi/agent/prompts/pr:update-desc.md": {
+    "source": "~/.claude/commands/pr/update-desc.md"
+  },
+  "~/.pi/agent/prompts/retro.md": {
+    "source": "~/.claude/commands/retro.md"
+  },
+  "~/.pi/agent/prompts/session-save.md": {
+    "source": "~/.claude/commands/session-save.md"
+  },
+  "~/.pi/agent/prompts/work:eod.md": {
+    "source": "~/.claude/commands/work/eod.md"
+  },
+  "~/.pi/agent/prompts/work:runners.md": {
+    "source": "~/.claude/commands/work/runners.md"
+  },
+  "~/.pi/agent/prompts/work:start-day.md": {
+    "source": "~/.claude/commands/work/start-day.md"
+  },
+  "~/.pi/agent/prompts/work:track-item.md": {
+    "source": "~/.claude/commands/work/track-item.md"
+  },
+  "~/.pi/agent/settings.json": {
+    "source": ""
+  },
+  "~/docs/agent-harnesses.json": {
+    "source": ""
+  },
+  "~/docs/agent-harnesses.md": {
+    "source": ""
+  }
+}

--- a/.agents/harness/hooks/safety.py
+++ b/.agents/harness/hooks/safety.py
@@ -74,6 +74,26 @@ PROTECTED_PATHS = re.compile(
     re.IGNORECASE,
 )
 
+# The control plane: the files that decide what this policy permits. An agent
+# able to edit these can switch off every other rule here — including the
+# protected-path list above — and the first time the guard blocks something it
+# will have a plausible reason to try. Keep them human-only: edit by hand.
+#
+# Deliberately narrow. Broad entries like `config\.yml$` or `\.gitignore$` would
+# block routine agent work across every repository, and the cost of that lands
+# on every session, not just on a self-improvement loop.
+CONTROL_PLANE_PATHS = re.compile(
+    r"("
+    r"/\.agents/harness/hooks/|"
+    r"/\.agents/harness/self-improve-policy\.json$|"
+    r"/scripts/agent-harnesses\.py$|"
+    r"/scripts/agent_plugins\.py$|"
+    r"/harness-guard\.(ts|py)$|"
+    r"/(write|bash)-guard\.sh$"
+    r")",
+    re.IGNORECASE,
+)
+
 SECRET_CONTENT = re.compile(
     r"("
     r"AKIA[0-9A-Z]{16}|"
@@ -132,6 +152,12 @@ def evaluate_write(*, path: str = "", content: str = "") -> GuardDecision:
         display_path = normalize_path_for_matching(path)
         if PROTECTED_PATHS.search(display_path):
             return GuardDecision("deny", f"protected file blocked: {path}")
+        if CONTROL_PLANE_PATHS.search(display_path):
+            return GuardDecision(
+                "deny",
+                f"control-plane file is human-only: {path}. It decides what the "
+                "guard permits, so edit it directly rather than through an agent.",
+            )
 
     if content and SECRET_CONTENT.search(content):
         return GuardDecision("deny", "secret-like content detected")

--- a/.agents/harness/hooks/safety.py
+++ b/.agents/harness/hooks/safety.py
@@ -6,10 +6,10 @@ Copyright: Ben Chatelain. Apache 2.0.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import os
 import re
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 
 
@@ -82,15 +82,24 @@ PROTECTED_PATHS = re.compile(
 # Deliberately narrow. Broad entries like `config\.yml$` or `\.gitignore$` would
 # block routine agent work across every repository, and the cost of that lands
 # on every session, not just on a self-improvement loop.
+#
+# Fragments end with a non-path lookahead rather than `$` so the same pattern
+# matches both a bare path and a path embedded in a shell command.
+_CONTROL_PLANE_FRAGMENTS = (
+    r"/\.agents/harness/hooks/",
+    r"/\.agents/harness/self-improve-policy\.json(?![\w.-])",
+    # The generated-path manifest is the whole basis of the generated-file deny
+    # rule, and load_generated_manifest() fails open. Blanking this file would
+    # silently unlock all 274 generated artifacts, so it is control plane too.
+    r"/\.agents/harness/generated-paths\.json(?![\w.-])",
+    r"/scripts/agent-harnesses\.py(?![\w.-])",
+    r"/scripts/agent_plugins\.py(?![\w.-])",
+    r"/harness-guard\.(?:ts|py)(?![\w.-])",
+    r"/(?:write|bash)-guard\.sh(?![\w.-])",
+)
+
 CONTROL_PLANE_PATHS = re.compile(
-    r"("
-    r"/\.agents/harness/hooks/|"
-    r"/\.agents/harness/self-improve-policy\.json$|"
-    r"/scripts/agent-harnesses\.py$|"
-    r"/scripts/agent_plugins\.py$|"
-    r"/harness-guard\.(ts|py)$|"
-    r"/(write|bash)-guard\.sh$"
-    r")",
+    "(?:" + "|".join(_CONTROL_PLANE_FRAGMENTS) + ")",
     re.IGNORECASE,
 )
 
@@ -140,6 +149,21 @@ def evaluate_command(command: str, *, cwd: str | None = None) -> GuardDecision:
     if any(pattern.search(command) for pattern in OBFUSCATED_EXECUTION):
         return GuardDecision("deny", "Obfuscated execution pattern detected")
 
+    # Path rules have to apply here too, not just in evaluate_write: `echo x >>
+    # safety.py` reaches the same file as a write tool, and until this existed
+    # one line of shell switched off every path rule in this module.
+    target = writes_to(command, PROTECTED_PATHS)
+    if target:
+        return GuardDecision("deny", f"protected file blocked: {target}")
+
+    target = writes_to(command, CONTROL_PLANE_PATHS)
+    if target:
+        return GuardDecision(
+            "deny",
+            f"control-plane file is human-only: {target}. It decides what the "
+            "guard permits, so edit it directly rather than through an agent.",
+        )
+
     warning = main_branch_commit_warning(command, cwd=cwd)
     if warning:
         return GuardDecision("warn", warning)
@@ -163,6 +187,47 @@ def evaluate_write(*, path: str = "", content: str = "") -> GuardDecision:
         return GuardDecision("deny", "secret-like content detected")
 
     return GuardDecision("allow")
+
+
+# Shell constructs that name a file the command writes to. Each captures the
+# span in which a target may appear; path-like tokens are pulled out of it and
+# matched against the ordinary path rules.
+_REDIRECT_TARGET = re.compile(r">>?\s*(?P<span>[^\s;|&<>]+)")
+_MUTATING_ARGV = re.compile(
+    r"\b(?:rm|mv|cp|tee|ln|install|truncate|shred|unlink|touch|chmod|chown)\b"
+    r"(?P<span>[^;|&]*)",
+    re.IGNORECASE,
+)
+_SED_INPLACE = re.compile(r"\bsed\b(?P<span>[^;|&]*?-i(?:\S*)?[^;|&]*)", re.IGNORECASE)
+_DD_TARGET = re.compile(r"\bdd\b[^;|&]*?\bof=(?P<span>[^\s;|&]+)", re.IGNORECASE)
+
+_PATH_TOKEN = re.compile(r"[^\s;|&<>'\"]*[/~][^\s;|&<>'\"]*")
+
+
+def candidate_write_targets(command: str) -> list[str]:
+    """Path-like tokens that a shell command appears to write to.
+
+    Regex, not a shell parser. It recognizes redirection, the common mutating
+    commands, `sed -i`, and `dd of=`. A here-doc, a `python3 -c` one-liner, or
+    an alias will get past it, and that is understood: the job here is to stop
+    the guard being switched off by an ordinary one-line edit, not to sandbox
+    the shell. The merge gate is what actually holds.
+    """
+
+    targets: list[str] = []
+    for pattern in (_REDIRECT_TARGET, _MUTATING_ARGV, _SED_INPLACE, _DD_TARGET):
+        for match in pattern.finditer(command):
+            targets.extend(_PATH_TOKEN.findall(match.group("span")))
+    return [token.strip("'\"") for token in targets if token.strip("'\"")]
+
+
+def writes_to(command: str, pattern: re.Pattern[str]) -> str:
+    """The first write target in `command` matching `pattern`, else ""."""
+
+    for target in candidate_write_targets(command):
+        if pattern.search(normalize_path_for_matching(target)):
+            return target
+    return ""
 
 
 def normalize_path_for_matching(path: str) -> str:

--- a/.agents/harness/self-improve-policy.json
+++ b/.agents/harness/self-improve-policy.json
@@ -1,0 +1,21 @@
+{
+  "_comment": "Autonomy tiers for harness self-improvement work. Hand-maintained: this file decides what an agent may change, so an agent must not be able to change it. It is covered by CONTROL_PLANE_PATHS in .agents/harness/hooks/safety.py.",
+  "auto_implement": [
+    "docs",
+    "ci-path-filter",
+    "tool-version-bump"
+  ],
+  "never": [
+    "generator-change",
+    "safety-policy",
+    "gitignore",
+    "git-filters",
+    "rulesets"
+  ],
+  "propose_only": [
+    "harness-config",
+    "build-script",
+    "tool-install"
+  ],
+  "version": 1
+}

--- a/.claude/hooks/scripts/pre-commit-format.sh
+++ b/.claude/hooks/scripts/pre-commit-format.sh
@@ -4,25 +4,34 @@ set -euo pipefail
 # Run `just format` before git commit to ensure consistent formatting.
 # Only stages files that formatting actually changed — preserves partial staging.
 # Uses git hash-object to compare content before/after, handling spaces in paths.
+#
+# No `declare -A` here. macOS ships bash 3.2, which has no associative arrays,
+# and settings.json invokes this as `bash <script>` rather than through the
+# shebang — so a bash 4 builtin makes the hook fail closed and block every
+# commit instead of formatting anything. Snapshot lines are "<hash> <path>",
+# and a path is recognized as changed when its line is absent from the earlier
+# snapshot; git hashes never contain spaces, so paths that do still round-trip.
 
-declare -A before_hashes
-while IFS= read -r f; do
-  [[ -f "$f" ]] && before_hashes["$f"]=$(git hash-object "$f")
-done < <(git diff --name-only)
+snapshot() {
+  while IFS= read -r f; do
+    [[ -f $f ]] && printf '%s %s\n' "$(git hash-object "$f")" "$f"
+  done < <(git diff --name-only)
+  return 0
+}
+
+before="$(snapshot)"
 
 just format 2>&1
 
 staged=0
-while IFS= read -r f; do
-  [[ -f "$f" ]] || continue
-  new_hash=$(git hash-object "$f")
-  old_hash=${before_hashes["$f"]:-}
-  if [[ -z "$old_hash" || "$old_hash" != "$new_hash" ]]; then
-    git add -- "$f"
+while IFS= read -r line; do
+  [[ -n $line ]] || continue
+  if ! printf '%s\n' "$before" | grep -qxF -- "$line"; then
+    git add -- "${line#* }"
     staged=1
   fi
-done < <(git diff --name-only)
+done <<<"$(snapshot)"
 
-if [[ "$staged" -eq 1 ]]; then
+if [[ $staged -eq 1 ]]; then
   echo '{"systemMessage":"Auto-formatted and staged changed files before commit."}'
 fi

--- a/.github/scripts/changed.sh
+++ b/.github/scripts/changed.sh
@@ -16,7 +16,11 @@ profile="${1:?usage: changed.sh <lint|parity>}"
 
 case "$profile" in
 lint)
-	pattern='^(\.config/(fish|home-manager|nushell)/|\.config/zsh/functions/|\.config/mise/config\.toml$|\.gitignore$|bin/|justfile$|scripts/|tests/|\.github/(workflows/lint\.yml|scripts/changed\.sh)$)'
+	# Mirrors what `just lint` actually reads: lint-yaml covers every tracked
+	# *.yml/*.yaml, lint-toml validates .codex/config.toml, and lint-python
+	# covers scripts/*.py. Narrower than this and a lint failure surfaces on
+	# some later unrelated pull request instead of the one that caused it.
+	pattern='^(\.config/(fish|home-manager|nushell)/|\.config/zsh/functions/|\.config/mise/config\.toml$|\.codex/config\.toml$|\.gitignore$|bin/|justfile$|scripts/|tests/|\.github/(workflows|scripts)/|.*\.ya?ml$)'
 	;;
 parity)
 	# .agents/skills/** is a generator input (SKILL_SOURCE) and belongs here:
@@ -46,7 +50,18 @@ if [[ -z $base ]] || ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
 	exit 0
 fi
 
-if git diff --name-only "$base" HEAD | grep -qE "$pattern"; then
+# Captured rather than piped into grep. Under `set -o pipefail`, `grep -q` exits
+# on its first match and the still-writing `git diff` takes SIGPIPE, which makes
+# the pipeline report failure — so a *matching* diff would have taken the else
+# branch and reported relevant=false, skipping a required check on exactly the
+# large pull requests that most need it.
+if ! changed_files="$(git diff --name-only "$base" HEAD)"; then
+	echo "diff failed; running everything" >&2
+	emit true
+	exit 0
+fi
+
+if grep -qE "$pattern" <<<"$changed_files"; then
 	emit true
 else
 	emit false

--- a/.github/scripts/changed.sh
+++ b/.github/scripts/changed.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Decide whether a workflow's expensive steps need to run for this event.
+#
+# `lint`, `test`, and `parity` are required status checks. A required check that
+# never runs leaves a pull request stuck on "Expected", so the workflows can no
+# longer filter at the `on:` trigger — they always start, and this script tells
+# them whether there is anything to do. Path lists live here only.
+#
+# Writes `relevant=true|false` to $GITHUB_OUTPUT. Fails open: anything other than
+# a pull request, or any trouble reading the diff, reports true.
+#
+# Copyright: Ben Chatelain. MIT
+set -euo pipefail
+
+profile="${1:?usage: changed.sh <lint|parity>}"
+
+case "$profile" in
+lint)
+	pattern='^(\.config/(fish|home-manager|nushell)/|\.config/zsh/functions/|\.config/mise/config\.toml$|\.gitignore$|bin/|justfile$|scripts/|tests/|\.github/(workflows/lint\.yml|scripts/changed\.sh)$)'
+	;;
+parity)
+	# .agents/skills/** is a generator input (SKILL_SOURCE) and belongs here:
+	# editing a shared skill can leave generated adapters stale.
+	pattern='^(\.agents/|\.claude/(commands|skills)/|\.codex/(agents|skills)/|\.config/opencode/|\.cursor/|\.gemini/|\.pi/|\.omp/|scripts/agent-harnesses\.py$|scripts/agent_plugins\.py$|docs/agent-harnesses\.|\.github/(workflows/agent-harness-parity\.yml|scripts/changed\.sh)$)'
+	;;
+*)
+	echo "unknown profile: $profile" >&2
+	exit 64
+	;;
+esac
+
+emit() {
+	echo "relevant=$1" >>"${GITHUB_OUTPUT:-/dev/stdout}"
+	echo "relevant=$1 (profile: $profile)" >&2
+}
+
+if [[ ${GITHUB_EVENT_NAME:-} != "pull_request" ]]; then
+	emit true
+	exit 0
+fi
+
+base="${BASE_SHA:-}"
+if [[ -z $base ]] || ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
+	echo "base commit unavailable; running everything" >&2
+	emit true
+	exit 0
+fi
+
+if git diff --name-only "$base" HEAD | grep -qE "$pattern"; then
+	emit true
+else
+	emit false
+fi

--- a/.github/scripts/changed.sh
+++ b/.github/scripts/changed.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Decide whether a workflow's expensive steps need to run for this event.
 #
-# `lint`, `test`, and `parity` are required status checks. A required check that
+# `lint`, `test`, and `harness-parity` are required status checks. A check that
 # never runs leaves a pull request stuck on "Expected", so the workflows can no
 # longer filter at the `on:` trigger — they always start, and this script tells
 # them whether there is anything to do. Path lists live here only.

--- a/.github/workflows/agent-harness-parity.yml
+++ b/.github/workflows/agent-harness-parity.yml
@@ -1,10 +1,11 @@
-name: Agent Harness Parity
+name: agent-harness
 
 on:
-  # No paths filter, deliberately: `parity` is a required status check, and a
-  # required check that never runs blocks the pull request permanently. The job
-  # always starts and decides for itself — see .github/scripts/changed.sh, which
-  # also covers .agents/skills/**, a generator input this filter used to miss.
+  # No paths filter, deliberately: `harness-parity` is a required status check,
+  # and a required check that never runs blocks the pull request permanently. The
+  # job always starts and decides for itself — see .github/scripts/changed.sh,
+  # which also covers .agents/skills/**, a generator input this filter used to
+  # miss.
   pull_request:
   workflow_dispatch:
   schedule:
@@ -15,7 +16,7 @@ permissions:
   issues: write
 
 jobs:
-  parity:
+  harness-parity:
     runs-on: ubuntu-latest
     env:
       HOME: ${{ github.workspace }}

--- a/.github/workflows/agent-harness-parity.yml
+++ b/.github/workflows/agent-harness-parity.yml
@@ -1,17 +1,11 @@
 name: Agent Harness Parity
 
 on:
+  # No paths filter, deliberately: `parity` is a required status check, and a
+  # required check that never runs blocks the pull request permanently. The job
+  # always starts and decides for itself — see .github/scripts/changed.sh, which
+  # also covers .agents/skills/**, a generator input this filter used to miss.
   pull_request:
-    paths:
-      - ".agents/harness/**"
-      - ".claude/commands/**"
-      - ".codex/agents/**"
-      - ".config/opencode/**"
-      - ".pi/agent/**"
-      - "docs/agent-harnesses.*"
-      - "scripts/agent-harnesses.py"
-      - "tests/agent-harnesses.bats"
-      - "justfile"
   workflow_dispatch:
   schedule:
     - cron: "17 14 * * 1"
@@ -27,23 +21,35 @@ jobs:
       HOME: ${{ github.workspace }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Detect relevant changes
+        id: changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: ./.github/scripts/changed.sh parity
 
       - uses: extractions/setup-just@v4
+        if: steps.changed.outputs.relevant == 'true'
 
       - name: Check generated harness parity
+        if: steps.changed.outputs.relevant == 'true'
         run: python3 scripts/agent-harnesses.py validate
 
       - name: Build parity report
+        if: steps.changed.outputs.relevant == 'true'
         run: python3 scripts/agent-harnesses.py audit > agent-harness-parity-report.md
 
       - name: Upload parity report
+        if: steps.changed.outputs.relevant == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: agent-harness-parity-report
           path: agent-harness-parity-report.md
 
       - name: Refresh parity issue
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && steps.changed.outputs.relevant == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/human-approval.yml
+++ b/.github/workflows/human-approval.yml
@@ -5,8 +5,20 @@ name: human-approval
 # A review count cannot serve here: GitHub disables self-approval, and this is a
 # solo repository, so `required_approving_review_count: 1` would deadlock every
 # pull request. Instead an agent labels its own work `agent-authored`, and this
-# check fails until a human adds `human-approved`. Applying a label is the human
-# act; the ruleset makes the check non-bypassable.
+# check fails until a human adds `human-approved`. Applying the label is the
+# human act.
+#
+# ADVISORY UNTIL THE RULESET LANDS. This check reports, but nothing yet stops a
+# merge without it: ruleset 13542903 has no required_status_checks rule and its
+# bypass_actors still grants repository admins `always`. Both are manual,
+# post-merge steps (spec 001, Out of scope), and until they are applied this
+# file documents an intent rather than enforcing one. Do not treat an
+# agent-authored pull request as gated before then.
+#
+# Nor does anything here prove a *human* applied the label — an agent with a
+# repo token can add it via the API. A guard rule against `gh label` would not
+# change that, only the route. Sign-off is trustworthy to the degree the token
+# handed to the agent is scoped, which is a separate piece of work.
 #
 # Human-authored pull requests carry no `agent-authored` label and pass straight
 # through, so this costs nothing on ordinary work.
@@ -37,11 +49,13 @@ jobs:
           LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
         run: |
           set -euo pipefail
-          if ! printf '%s' "$LABELS" | grep -q '"agent-authored"'; then
+          # jq, not grep: a substring match on the JSON text also accepts a
+          # label crafted to embed the name, e.g. `x"human-approved`.
+          if ! jq -e 'index("agent-authored")' <<<"$LABELS" >/dev/null; then
             echo "No agent-authored label — human-authored pull request, gate not applicable."
             exit 0
           fi
-          if printf '%s' "$LABELS" | grep -q '"human-approved"'; then
+          if jq -e 'index("human-approved")' <<<"$LABELS" >/dev/null; then
             echo "human-approved label present — sign-off recorded."
             exit 0
           fi

--- a/.github/workflows/human-approval.yml
+++ b/.github/workflows/human-approval.yml
@@ -1,0 +1,49 @@
+name: human-approval
+
+# The merge gate for agent-authored pull requests.
+#
+# A review count cannot serve here: GitHub disables self-approval, and this is a
+# solo repository, so `required_approving_review_count: 1` would deadlock every
+# pull request. Instead an agent labels its own work `loop-authored`, and this
+# check fails until a human adds `human-approved`. Applying a label is the human
+# act; the ruleset makes the check non-bypassable.
+#
+# Human-authored pull requests carry no `loop-authored` label and pass straight
+# through, so this costs nothing on ordinary work.
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+      - ready_for_review
+      - converted_to_draft
+
+permissions:
+  contents: read
+
+jobs:
+  human-approval:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require explicit sign-off on agent-authored changes
+        env:
+          # Label names reach the runner as JSON, never interpolated into the
+          # script body — a label is attacker-controllable text.
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          set -euo pipefail
+          if ! printf '%s' "$LABELS" | grep -q '"loop-authored"'; then
+            echo "No loop-authored label — human-authored pull request, gate not applicable."
+            exit 0
+          fi
+          if printf '%s' "$LABELS" | grep -q '"human-approved"'; then
+            echo "human-approved label present — sign-off recorded."
+            exit 0
+          fi
+          echo "::error::This pull request is labeled loop-authored. Read the diff, then add the 'human-approved' label to merge."
+          exit 1

--- a/.github/workflows/human-approval.yml
+++ b/.github/workflows/human-approval.yml
@@ -4,11 +4,11 @@ name: human-approval
 #
 # A review count cannot serve here: GitHub disables self-approval, and this is a
 # solo repository, so `required_approving_review_count: 1` would deadlock every
-# pull request. Instead an agent labels its own work `loop-authored`, and this
+# pull request. Instead an agent labels its own work `agent-authored`, and this
 # check fails until a human adds `human-approved`. Applying a label is the human
 # act; the ruleset makes the check non-bypassable.
 #
-# Human-authored pull requests carry no `loop-authored` label and pass straight
+# Human-authored pull requests carry no `agent-authored` label and pass straight
 # through, so this costs nothing on ordinary work.
 
 on:
@@ -37,13 +37,13 @@ jobs:
           LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
         run: |
           set -euo pipefail
-          if ! printf '%s' "$LABELS" | grep -q '"loop-authored"'; then
-            echo "No loop-authored label — human-authored pull request, gate not applicable."
+          if ! printf '%s' "$LABELS" | grep -q '"agent-authored"'; then
+            echo "No agent-authored label — human-authored pull request, gate not applicable."
             exit 0
           fi
           if printf '%s' "$LABELS" | grep -q '"human-approved"'; then
             echo "human-approved label present — sign-off recorded."
             exit 0
           fi
-          echo "::error::This pull request is labeled loop-authored. Read the diff, then add the 'human-approved' label to merge."
+          echo "::error::This pull request is labeled agent-authored. Read the diff, then add the 'human-approved' label to merge."
           exit 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,12 @@ on:
       - "justfile"
       - "scripts/**"
       - "tests/**"
-      - ".github/workflows/lint.yml"
+      - ".codex/config.toml"
+      - "**.yml"
+      - "**.yaml"
+      # changed.sh decides whether the pull_request run does any work, so a
+      # main-branch commit touching only it still needs a post-merge lint.
+      - ".github/scripts/**"
   # No paths filter on pull_request, deliberately. `lint` and `test` are required
   # status checks, and a required check that never runs leaves the pull request
   # stuck on "Expected" forever. The jobs always start and decide for themselves

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,19 +15,11 @@ on:
       - "scripts/**"
       - "tests/**"
       - ".github/workflows/lint.yml"
+  # No paths filter on pull_request, deliberately. `lint` and `test` are required
+  # status checks, and a required check that never runs leaves the pull request
+  # stuck on "Expected" forever. The jobs always start and decide for themselves
+  # whether there is work to do — see the "Detect relevant changes" step.
   pull_request:
-    paths:
-      - ".config/fish/**"
-      - ".config/home-manager/**"
-      - ".config/nushell/**"
-      - ".config/zsh/functions/**"
-      - ".config/mise/config.toml"
-      - ".gitignore"
-      - "bin/**"
-      - "justfile"
-      - "scripts/**"
-      - "tests/**"
-      - ".github/workflows/lint.yml"
   schedule:
     # Weekly Monday 06:00 UTC — catch drift from tool updates
     - cron: "0 6 * * 1"
@@ -47,27 +39,39 @@ jobs:
       MISE_ENABLE_TOOLS: "just,shellcheck,ruff,bats,github:nushell/nushell,python,pipx:yamllint"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Detect relevant changes
+        id: changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: ./.github/scripts/changed.sh lint
 
       # Let the action run the install: it only caches tools it installed
       # itself, so `install: false` plus a separate `mise install` step meant
       # the cache was never written. install_args keeps the tool set scoped.
       - name: Install mise and tools
+        if: steps.changed.outputs.relevant == 'true'
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           install_args: "just shellcheck ruff bats github:nushell/nushell python pipx:yamllint"
 
       - name: Install fish and zsh
+        if: steps.changed.outputs.relevant == 'true'
         run: |
           # Runner-provided Microsoft repositories intermittently return 403.
           sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update && sudo apt-get install -y fish zsh
 
       - name: Lint
+        if: steps.changed.outputs.relevant == 'true'
         run: |
           eval "$(mise activate bash)"
           just lint
 
       - name: Validate nix flake
+        if: steps.changed.outputs.relevant == 'true'
         run: nix flake show --json "$HOME/.config/home-manager" 2>&1 | head -20
         continue-on-error: true
 
@@ -86,21 +90,33 @@ jobs:
       GIT_CONFIG_VALUE_0: "false"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Detect relevant changes
+        id: changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: ./.github/scripts/changed.sh lint
 
       - name: Install mise and tools
+        if: steps.changed.outputs.relevant == 'true'
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:
           install_args: "just shellcheck ruff bats bat starship aqua:shenwei356/rush github:nushell/nushell"
 
       - name: Install fish and test-exercised tools
+        if: steps.changed.outputs.relevant == 'true'
         run: brew install fish diff-so-fancy git-subrepo
 
       - name: Generate SSH key for sshkey tests
+        if: steps.changed.outputs.relevant == 'true'
         run: |
           mkdir -p "$HOME/.ssh"
           ssh-keygen -q -t ed25519 -N "" -f "$HOME/.ssh/id_ed25519"
 
       - name: Test
+        if: steps.changed.outputs.relevant == 'true'
         run: |
           eval "$(mise activate bash)"
           just test

--- a/docs/specs/001-self-improvement-loop.md
+++ b/docs/specs/001-self-improvement-loop.md
@@ -92,13 +92,13 @@ item stands on its own if the loop is never built.
    source to edit instead. This runs on the existing hot path and is therefore
    already wired into all seven harnesses.
 
-5. **Workflow checks always report.** `lint`, `test`, and `parity` are currently
-   filtered at the `on:` trigger, so a pull request touching none of their paths
-   produces no check at all. Making them required in that state would deadlock
-   every such pull request. The filter moves into the jobs: the workflow always
-   runs, and the expensive step is skipped when irrelevant. `.agents/skills/**`
-   joins the parity filter — it is a generator input (`SKILL_SOURCE`) that today
-   triggers no parity signal.
+5. **Workflow checks always report.** `lint`, `test`, and `harness-parity` are
+   currently filtered at the `on:` trigger, so a pull request touching none of
+   their paths produces no check at all. Making them required in that state
+   would deadlock every such pull request. The filter moves into the jobs: the
+   workflow always runs, and the expensive step is skipped when irrelevant.
+   `.agents/skills/**` joins the parity filter — it is a generator input
+   (`SKILL_SOURCE`) that today triggers no parity signal.
 
 6. **A `human-approval` check.** Agent-authored pull requests carry an
    `agent-authored` label; the check fails until a human adds `human-approved`.
@@ -137,5 +137,5 @@ The ruleset changes are verified separately, after merge:
 
 ```
 gh api repos/phatblat/dotfiles/rulesets/13542903 --jq '.bypass_actors'   # → []
-gh pr checks <pr>                                                        # → lint, test, parity, human-approval
+gh pr checks <pr>                                          # → lint, test, harness-parity, human-approval
 ```

--- a/docs/specs/001-self-improvement-loop.md
+++ b/docs/specs/001-self-improvement-loop.md
@@ -100,8 +100,8 @@ item stands on its own if the loop is never built.
    joins the parity filter — it is a generator input (`SKILL_SOURCE`) that today
    triggers no parity signal.
 
-6. **A `human-approval` check.** Loop-authored pull requests carry a
-   `loop-authored` label; the check fails until a human adds `human-approved`.
+6. **A `human-approval` check.** Agent-authored pull requests carry an
+   `agent-authored` label; the check fails until a human adds `human-approved`.
    Applying a label is the human gate, and the ruleset makes it non-bypassable.
    A review count of 1 does not work here — GitHub disables self-approval, and a
    solo maintainer would deadlock.

--- a/docs/specs/001-self-improvement-loop.md
+++ b/docs/specs/001-self-improvement-loop.md
@@ -1,7 +1,10 @@
 ---
 id: 001
 title: Self-improving harness loop — safety substrate first
-category: harness-config
+# safety-policy, not harness-config: this spec edits CONTROL_PLANE_PATHS and
+# creates the autonomy policy, both `never` tier. auto_implement: false already
+# follows from that, but the category should not understate it.
+category: safety-policy
 status: approved
 approved_by: phatblat
 approved_at: 2026-08-12
@@ -19,12 +22,17 @@ evidence:
 targets:
   sources:
     - ".agents/harness/hooks/safety.py"
+    - ".agents/harness/self-improve-policy.json"
     - "scripts/agent-harnesses.py"
+    - ".github/scripts/changed.sh"
     - ".github/workflows/lint.yml"
     - ".github/workflows/agent-harness-parity.yml"
     - ".github/workflows/human-approval.yml"
     - "tests/agent-harnesses.bats"
-  generated: []
+  # generated-paths.json is emitted by render_all(), so it is listed here rather
+  # than under sources even though the spec causes it to exist.
+  generated:
+    - ".agents/harness/generated-paths.json"
 verification: "HOME=$PWD just check"
 rollback: "git revert <sha>"
 ---

--- a/docs/specs/001-self-improvement-loop.md
+++ b/docs/specs/001-self-improvement-loop.md
@@ -1,0 +1,141 @@
+---
+id: 001
+title: Self-improving harness loop — safety substrate first
+category: harness-config
+status: approved
+approved_by: phatblat
+approved_at: 2026-08-12
+auto_implement: false
+evidence:
+  - signal: ruleset-bypass-actor
+    count: 1
+    window: 2026-08-11/2026-08-11
+  - signal: control-plane-writable
+    count: 7
+    window: 2026-08-11/2026-08-11
+  - signal: generated-file-undetectable-by-header
+    count: 4
+    window: 2026-08-11/2026-08-11
+targets:
+  sources:
+    - ".agents/harness/hooks/safety.py"
+    - "scripts/agent-harnesses.py"
+    - ".github/workflows/lint.yml"
+    - ".github/workflows/agent-harness-parity.yml"
+    - ".github/workflows/human-approval.yml"
+    - "tests/agent-harnesses.bats"
+  generated: []
+verification: "HOME=$PWD just check"
+rollback: "git revert <sha>"
+---
+
+## Problem
+
+The goal is a loop that watches how the harness underperforms, proposes units of
+work, and — once a human approves — implements them behind a pull request. Three
+findings from designing it say the loop cannot be built yet, because the controls
+it would run under do not hold.
+
+**The pull request gate does not exist.** Ruleset 13542903 ("Protect main")
+carries `bypass_actors: [{actor_id: 5, actor_type: RepositoryRole, bypass_mode:
+always}]`. Role 5 is admin; the repository owner is an admin, and any agent runs
+with the owner's token. Alongside that: `required_approving_review_count: 0`, and
+no `required_status_checks` rule at all, so the 32 bats files in `tests/` do not
+gate a merge. Ruleset 13416093 ("Copilot Reviews") sets
+`review_draft_pull_requests: false`, so the draft pull requests a loop would open
+receive no machine review either. "A human reviews and merges" is a convention,
+not a control.
+
+**The guard does not defend the guard.** `PROTECTED_PATHS` in
+`.agents/harness/hooks/safety.py` lists credentials only. Verified by executing
+the policy:
+
+```
+guard --tool write --path .agents/harness/hooks/safety.py  → allow
+guard --tool bash --command "gh pr merge --admin --squash" → allow
+guard --tool bash --command "git push --force phatblat main" → allow
+```
+
+An agent whose stated job is "tweak harness configuration" has write access to
+its own kill switch, and a plausible reason to use it the first time the guard
+blocks something.
+
+**Generated files cannot be detected by grepping the header.** `MANAGED_HEADER`
+is a comment, so the four generated JSON artifacts — `docs/agent-harnesses.json`,
+`.pi/agent/agents.json`, and both adapter `plugin.json` files — carry no marker.
+An agent editing one loses the work at the next `just harness-generate`, with no
+warning. `render_all()` is the only authoritative registry, and it is far too
+expensive to call on the guard hot path, which defers imports specifically to
+stay near 0.06s per call.
+
+These are pre-existing conditions. They are true today, with or without the loop.
+
+## Proposed change
+
+Ship the safety substrate only. No scheduler, no model calls, no tracker. Each
+item stands on its own if the loop is never built.
+
+1. **Control-plane paths become human-only.** A `CONTROL_PLANE_PATHS` pattern in
+   `safety.py` denies agent writes to the guard, the generator, and the per-harness
+   guard shims, with a message that says to edit them by hand. Distinct from
+   `PROTECTED_PATHS` so the denial reason stays honest — these are not credentials.
+
+2. **A generated-path manifest.** `render_all()` emits
+   `.agents/harness/generated-paths.json`, mapping every generated path to its
+   producer and its hand-written source. Being a `render_all()` output, it is
+   parity-checked by the existing `just harness-check` and cannot drift.
+
+3. **A `provenance` subcommand** reports `generated` / `source` / `generator` /
+   `other` for a path, reading the manifest rather than re-rendering.
+
+4. **A guard rule** denies `write`/`edit` to any path in the manifest, naming the
+   source to edit instead. This runs on the existing hot path and is therefore
+   already wired into all seven harnesses.
+
+5. **Workflow checks always report.** `lint`, `test`, and `parity` are currently
+   filtered at the `on:` trigger, so a pull request touching none of their paths
+   produces no check at all. Making them required in that state would deadlock
+   every such pull request. The filter moves into the jobs: the workflow always
+   runs, and the expensive step is skipped when irrelevant. `.agents/skills/**`
+   joins the parity filter — it is a generator input (`SKILL_SOURCE`) that today
+   triggers no parity signal.
+
+6. **A `human-approval` check.** Loop-authored pull requests carry a
+   `loop-authored` label; the check fails until a human adds `human-approved`.
+   Applying a label is the human gate, and the ruleset makes it non-bypassable.
+   A review count of 1 does not work here — GitHub disables self-approval, and a
+   solo maintainer would deadlock.
+
+## Out of scope
+
+Not in this change, deliberately:
+
+- **The loop itself.** No detector, no scheduler, no synthesis, no specs written
+  by a model. Whether recurring harness-attributable friction exists here is an
+  untested premise; the next step is to measure it, not to build machinery to act
+  on it.
+- **The three `pi-*` plugins.** All peer-depend on `@earendil-works/*` or
+  `@mariozechner/*`; this harness is `@oh-my-pi/*`, distributed as a compiled
+  binary. `@askjo/pi-reflect` additionally auto-commits transcript-derived content
+  to git, which in a public repository rooted at `$HOME` is the highest-risk item
+  considered. Revisit `pi-experiences` only after the loop exists.
+- **aven.** Justified only for the private pre-approval stage, which does not
+  exist yet. Adopting it now would create a tracker with nothing to track.
+- **The ruleset edits themselves.** `bypass_actors` and `required_status_checks`
+  are applied through the GitHub API, not this repository, and must land *after*
+  the workflow changes reach `main` — otherwise the new required checks block
+  every pull request. Category `rulesets` is `never`: a human runs them.
+
+## Verification
+
+`HOME=$PWD just check` — lint, spelling, harness parity, and bats.
+
+New bats coverage asserts the guard denies a write to a generated file, denies a
+write to `safety.py`, and that every key in `generated-paths.json` resolves.
+
+The ruleset changes are verified separately, after merge:
+
+```
+gh api repos/phatblat/dotfiles/rulesets/13542903 --jq '.bypass_actors'   # → []
+gh pr checks <pr>                                                        # → lint, test, parity, human-approval
+```

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,82 @@
+# Specs
+
+One file per unit of harness work. A spec is a **rejection interface**: it exists
+so a change can be killed in thirty seconds of reading, before anyone spends
+tokens building it. If a spec takes longer to read than the diff would, skip the
+spec and write the diff.
+
+## When a spec is worth writing
+
+- The change touches more than one harness, or the generator.
+- A wrong guess is expensive to unwind.
+- The work will be implemented by an agent that did not participate in the
+  decision.
+
+Anything under a screenful of mechanically verifiable diff (`just check` passes
+or it does not) does not need one.
+
+## Lifecycle
+
+```
+draft ──→ approved ──→ implementing ──→ in-review ──→ merged
+   └──────→ rejected
+```
+
+Drafts live outside this repository (the repo is public, and a draft may quote
+paths, hostnames, or errors from unrelated work). A spec is written here only
+once it has been read and approved by a human — the approval boundary and the
+redaction boundary are the same line.
+
+## Categories
+
+`category` decides how much autonomy an implementer has. The authoritative list
+is `.agents/harness/self-improve-policy.json`; the summary:
+
+| Tier | Categories | Autonomy |
+| --- | --- | --- |
+| auto | `docs`, `ci-path-filter`, `tool-version-bump` | May implement and open a draft PR |
+| propose | `harness-config`, `build-script`, `tool-install` | May implement; the diff needs review, not just the spec |
+| never | `generator-change`, `safety-policy`, `gitignore`, `git-filters`, `rulesets` | Describe the problem only. A human writes the code |
+
+The `never` tier is not a preference. Those paths decide what everything else is
+allowed to do, so an agent that can edit them can grant itself the rest.
+
+## Frontmatter
+
+```yaml
+---
+id: 004
+title: Short imperative phrase
+category: harness-config
+status: approved
+approved_by: phatblat
+approved_at: 2026-08-12
+auto_implement: false
+evidence:
+  - signal: parity-stale-no-ci
+    count: 4
+    window: 2026-07-14/2026-08-11
+targets:
+  sources: [".github/workflows/agent-harness-parity.yml"]
+  generated: []      # must stay empty unless category is generator-change
+verification: "HOME=$PWD just check"
+rollback: "git revert <sha>"
+---
+```
+
+`targets.generated` is the self-check. Before implementing, run
+`python3 scripts/agent-harnesses.py provenance --path <p>` on every entry in
+`targets.sources`; if any resolves to `generated`, the spec is wrong and the
+work stops. Generated files are overwritten by the next `just harness-generate`,
+so editing one silently discards the change.
+
+## Body
+
+Four headings, in this order. Keep it short.
+
+```markdown
+## Problem
+## Proposed change
+## Out of scope
+## Verification
+```

--- a/scripts/agent-harnesses.py
+++ b/scripts/agent-harnesses.py
@@ -18,7 +18,13 @@ from typing import TYPE_CHECKING, Any
 # per call). Non-guard invocations import everything eagerly, exactly as before;
 # the `TYPE_CHECKING or` prefix keeps the names bound for static analysis while
 # staying conditional at runtime.
-if TYPE_CHECKING or not (len(sys.argv) >= 2 and sys.argv[1] == "guard"):
+#
+# `provenance` shares the fast path for a second reason: `tomllib` needs Python
+# 3.11+, and the interpreter on PATH under launchd and other non-login contexts
+# is the system 3.9. Anything a scheduled job or a hook may call has to load
+# without it.
+FAST_PATH_ACTIONS = {"guard", "provenance"}
+if TYPE_CHECKING or not (len(sys.argv) >= 2 and sys.argv[1] in FAST_PATH_ACTIONS):
     import argparse
     import shutil
     import subprocess
@@ -34,6 +40,11 @@ sys.dont_write_bytecode = True
 HOME = Path(os.environ.get("HOME", str(Path.home()))).resolve()
 ROOT = HOME
 SHARED = ROOT / ".agents" / "harness"
+# Every path render_all() writes, mapped to the hand-written file behind it. The
+# `guard` hot path reads this instead of calling render_all(), which would render
+# every artifact on every tool call.
+GENERATED_MANIFEST = SHARED / "generated-paths.json"
+GENERATOR_PATH = ROOT / "scripts" / "agent-harnesses.py"
 COMMAND_SOURCE = ROOT / ".claude" / "commands"
 AGENT_SOURCE = ROOT / ".codex" / "agents"
 SKILL_SOURCE = ROOT / ".agents" / "skills"
@@ -174,8 +185,9 @@ ATTRIBUTE_MAPPINGS = [
 
 sys.path.insert(0, str(SHARED / "hooks"))
 try:
-    from safety import evaluate  # type: ignore
+    from safety import GuardDecision, evaluate  # type: ignore
 except ImportError as exc:  # pragma: no cover - only hit before installation
+    GuardDecision = None  # type: ignore
     evaluate = None  # type: ignore
     SAFETY_IMPORT_ERROR = exc
 else:
@@ -217,6 +229,12 @@ def main() -> int:
     guard_parser.add_argument("--content", default="")
     guard_parser.add_argument("--cwd", default=str(ROOT))
 
+    provenance_parser = subparsers.add_parser(
+        "provenance", help="Report whether a path is generated, source, or neither"
+    )
+    provenance_parser.add_argument("--path", required=True)
+    provenance_parser.add_argument("--json", action="store_true", help="Emit JSON")
+
     args = parser.parse_args()
     if args.action == "inventory":
         return command_inventory(json_output=args.json)
@@ -228,6 +246,8 @@ def main() -> int:
         return command_audit(json_output=args.json)
     if args.action == "guard":
         return command_guard(args)
+    if args.action == "provenance":
+        return command_provenance(args)
     raise AssertionError(args.action)
 
 
@@ -484,6 +504,10 @@ def command_guard(args: argparse.Namespace) -> int:
         content=args.content,
         cwd=args.cwd,
     )
+    if decision.allowed and args.path:
+        generated = generated_path_warning(args.tool, args.path)
+        if generated:
+            decision = GuardDecision("deny", generated)
     payload = {
         "harness": args.harness,
         "tool": args.tool,
@@ -492,6 +516,102 @@ def command_guard(args: argparse.Namespace) -> int:
     }
     print(json.dumps(payload, sort_keys=True))
     return 0 if decision.allowed else 2
+
+
+def load_generated_manifest() -> dict[str, dict[str, str]]:
+    """Read GENERATED_MANIFEST, or return {} when it is missing or unreadable.
+
+    Fails open on purpose: a missing manifest must not wedge every write in every
+    harness. `just harness-check` is what catches the manifest going stale.
+    """
+
+    try:
+        data = json.loads(GENERATED_MANIFEST.read_text())
+    except (OSError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def generated_relpath(path: str) -> str | None:
+    """Return the manifest key for `path`, or None when it is not generated.
+
+    Matches on the tail of the path rather than on equality so that a copy of the
+    repository checked out as a worktree — where the same artifact lives under a
+    different prefix — is still recognized as generated.
+    """
+
+    manifest = load_generated_manifest()
+    if not manifest:
+        return None
+    candidate = Path(os.path.expanduser(path))
+    try:
+        candidate = candidate.resolve()
+    except OSError:
+        pass
+    posix = candidate.as_posix()
+    for key in manifest:
+        rel = key.removeprefix("~/")
+        if posix == rel or posix.endswith("/" + rel):
+            return key
+    return None
+
+
+def generated_path_warning(tool: str, path: str) -> str:
+    """Explain why `path` must not be written, when it is a generated artifact."""
+
+    if tool.lower().strip() not in {
+        "write",
+        "edit",
+        "multiedit",
+        "file_write",
+        "file_edit",
+    }:
+        return ""
+    key = generated_relpath(path)
+    if key is None:
+        return ""
+    source = load_generated_manifest().get(key, {}).get("source") or ""
+    target = f"Edit {source} instead" if source else "Edit its source instead"
+    return (
+        f"{key} is generated by scripts/agent-harnesses.py and will be "
+        f"overwritten by the next `just harness-generate`. {target}, then "
+        "regenerate."
+    )
+
+
+def command_provenance(args: argparse.Namespace) -> int:
+    key = generated_relpath(args.path)
+    resolved = display_path(Path(os.path.expanduser(args.path)))
+    if key is not None:
+        kind = "generated"
+        source = load_generated_manifest().get(key, {}).get("source") or ""
+    elif resolved in {
+        display_path(GENERATOR_PATH),
+        display_path(SHARED / "hooks" / "safety.py"),
+    }:
+        kind, source = "generator", ""
+    elif any(
+        _is_within(args.path, root)
+        for root in (COMMAND_SOURCE, AGENT_SOURCE, SKILL_SOURCE)
+    ):
+        kind, source = "source", ""
+    else:
+        kind, source = "other", ""
+
+    payload = {"path": resolved, "kind": kind, "source": source}
+    if args.json:
+        print(json.dumps(payload, sort_keys=True))
+    else:
+        print(f"{kind}\t{resolved}" + (f"\t{source}" if source else ""))
+    return 0
+
+
+def _is_within(path: str, root: Path) -> bool:
+    try:
+        Path(os.path.expanduser(path)).resolve().relative_to(root.resolve())
+    except (OSError, ValueError):
+        return False
+    return True
 
 
 def build_inventory(*, include_prompts: bool = False) -> dict[str, Any]:
@@ -560,6 +680,11 @@ def render_all() -> dict[Path, str]:
     inventory = build_inventory(include_prompts=True)
     commands = inventory["commands"]
     agents = inventory["agents"]
+    # Reverse map from each generated artifact to the hand-written file it came
+    # from. Populated by diffing the keys of `rendered` after each loop iteration
+    # rather than by restating the target paths, so a new adapter cannot be added
+    # without its provenance following. Serialized as GENERATED_MANIFEST below.
+    provenance: dict[Path, str] = {}
     rendered: dict[Path, str] = {
         SHARED / "README.md": render_shared_readme(commands, agents),
         SHARED / "instructions.md": render_instructions(),
@@ -595,6 +720,7 @@ def render_all() -> dict[Path, str]:
 
     for command in commands:
         source = ROOT / command["source"].replace("~/", "")
+        emitted = set(rendered)
         rel = Path(command["id"] + ".md")
         rendered[SHARED / "commands" / rel] = render_shared_command(source.read_text())
         rendered[OPEN_CODE / "commands" / f"{command['native']}.md"] = (
@@ -605,9 +731,11 @@ def render_all() -> dict[Path, str]:
         )
         rendered[ANTIGRAVITY_COMMANDS / rel] = render_antigravity_command(command)
         rendered[CURSOR_HARNESS / "commands" / rel] = render_cursor_command(command)
+        record_provenance(provenance, rendered, emitted, source)
 
     for agent in agents:
         source = ROOT / agent["source"].replace("~/", "")
+        emitted = set(rendered)
         rendered[SHARED / "agents" / f"{agent['id']}.toml"] = render_shared_agent(
             source.read_text()
         )
@@ -621,15 +749,21 @@ def render_all() -> dict[Path, str]:
         rendered[CURSOR_HARNESS / "agents" / f"{agent['id']}.md"] = render_cursor_agent(
             agent
         )
+        record_provenance(provenance, rendered, emitted, source)
 
     for skill_name in inventory["skills"]["paths"]:
+        source = SKILL_SOURCE / skill_name / "SKILL.md"
+        emitted = set(rendered)
         rendered[ANTIGRAVITY_HARNESS / "skills" / skill_name / "SKILL.md"] = (
             render_antigravity_skill(skill_name)
         )
         rendered[CURSOR_HARNESS / "skills" / skill_name / "SKILL.md"] = (
             render_cursor_skill(skill_name)
         )
+        record_provenance(provenance, rendered, emitted, source)
     for skill_name in sorted(NATIVE_SKILL_ADAPTERS & set(inventory["skills"]["paths"])):
+        source = SKILL_SOURCE / skill_name / "SKILL.md"
+        emitted = set(rendered)
         manual_only = skill_name in MANUAL_SKILL_ADAPTERS
         rendered[CLAUDE_SKILLS / skill_name / "SKILL.md"] = render_claude_skill(
             skill_name, manual_only=manual_only
@@ -644,8 +778,40 @@ def render_all() -> dict[Path, str]:
         rendered[OPEN_CODE_SKILLS / skill_name / "SKILL.md"] = render_opencode_skill(
             skill_name
         )
+        record_provenance(provenance, rendered, emitted, source)
+
+    # The manifest describes itself too, so `provenance` never reports a
+    # generated file as untracked merely because it is the manifest.
+    provenance.setdefault(GENERATED_MANIFEST, "")
+    for target in rendered:
+        provenance.setdefault(target, "")
+    rendered[GENERATED_MANIFEST] = (
+        json.dumps(
+            {
+                display_path(target): {"source": source}
+                for target, source in sorted(
+                    provenance.items(), key=lambda item: display_path(item[0])
+                )
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
 
     return rendered
+
+
+def record_provenance(
+    provenance: dict[Path, str],
+    rendered: dict[Path, str],
+    emitted: set[Path],
+    source: Path,
+) -> None:
+    """Attribute every artifact added since `emitted` was captured to `source`."""
+
+    for target in rendered.keys() - emitted:
+        provenance[target] = display_path(source)
 
 
 def render_shared_readme(

--- a/tests/agent-harnesses.bats
+++ b/tests/agent-harnesses.bats
@@ -571,12 +571,49 @@ if missing:
   for target in \
     ".agents/harness/hooks/safety.py" \
     "scripts/agent-harnesses.py" \
-    ".agents/harness/self-improve-policy.json"; do
+    ".agents/harness/self-improve-policy.json" \
+    ".agents/harness/generated-paths.json"; do
     run python3 "$SCRIPT" guard --harness omp --tool write \
       --path "$HOME/$target" --content "x"
 
     [ "$status" -eq 2 ]
     [ "$(printf '%s' "$output" | jq -r '.decision')" = "deny" ]
+  done
+}
+
+# The path rules were write-tool-only, so `echo x >> safety.py` reached the
+# guard's own source and one redirect could blank the generated-path manifest,
+# taking every generated artifact unprotected with it.
+@test "agent-harnesses: guard denies shell writes to protected and control-plane paths" {
+  for command in \
+    "echo x >> $HOME/.agents/harness/hooks/safety.py" \
+    "echo '{}' > $HOME/.agents/harness/generated-paths.json" \
+    "rm $HOME/.agents/harness/generated-paths.json" \
+    "mv /tmp/x $HOME/.agents/harness/self-improve-policy.json" \
+    "sed -i '' s/deny/allow/ $HOME/scripts/agent-harnesses.py" \
+    "cp /tmp/evil $HOME/.claude/.credentials.json" \
+    "echo x >> $HOME/.ssh/id_rsa"; do
+    run python3 "$SCRIPT" guard --harness omp --tool bash --command "$command"
+
+    [ "$status" -eq 2 ]
+    [ "$(printf '%s' "$output" | jq -r '.decision')" = "deny" ]
+  done
+}
+
+# The guard shells out to the generator, so denying every command that merely
+# names a control-plane path would deadlock the harness against itself.
+@test "agent-harnesses: guard allows reads and unrelated writes near the control plane" {
+  for command in \
+    "python3 $HOME/scripts/agent-harnesses.py generate" \
+    "python3 $HOME/scripts/agent-harnesses.py validate 2>/dev/null" \
+    "cat $HOME/.agents/harness/hooks/safety.py" \
+    "grep -n deny $HOME/scripts/agent-harnesses.py" \
+    "echo hi > /tmp/unrelated.txt" \
+    "rm -f build/out.txt"; do
+    run python3 "$SCRIPT" guard --harness omp --tool bash --command "$command"
+
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | jq -r '.decision')" = "allow" ]
   done
 }
 

--- a/tests/agent-harnesses.bats
+++ b/tests/agent-harnesses.bats
@@ -524,3 +524,72 @@ SCRIPT="$HOME/scripts/agent-harnesses.py"
     [[ "$reason" == *"protected 'main' branch"* ]]
   done
 }
+
+@test "agent-harnesses: generated-paths manifest resolves and covers header-less artifacts" {
+  manifest="$HOME/.agents/harness/generated-paths.json"
+  [ -f "$manifest" ]
+
+  # Every key must name a file that exists, or the guard denies writes to paths
+  # that are gone while missing the ones that are not.
+  run python3 -c 'import json, sys
+from pathlib import Path
+home = Path(sys.argv[2])
+manifest = json.loads(Path(sys.argv[1]).read_text())
+missing = [k for k in manifest if not (home / k[2:]).exists()]
+if missing:
+    print("missing:", missing[:5])
+    raise SystemExit(1)
+' "$manifest" "$HOME"
+  [ "$status" -eq 0 ]
+
+  # These artifacts are JSON and cannot carry MANAGED_HEADER, so the manifest is
+  # the only way the guard can recognize them as generated.
+  run jq -e '."~/.pi/agent/agents.json"' "$manifest"
+  [ "$status" -eq 0 ]
+  run jq -e '."~/.agents/harness/generated-paths.json"' "$manifest"
+  [ "$status" -eq 0 ]
+}
+
+@test "agent-harnesses: guard denies writes to generated artifacts and names the source" {
+  run python3 "$SCRIPT" guard --harness omp --tool write \
+    --path "$HOME/.agents/harness/commands/git/commit.md" --content "x"
+
+  [ "$status" -eq 2 ]
+  [ "$(printf '%s' "$output" | jq -r '.decision')" = "deny" ]
+  [[ "$(printf '%s' "$output" | jq -r '.reason')" == *".claude/commands/git/commit.md"* ]]
+}
+
+@test "agent-harnesses: guard allows writes to hand-written sources" {
+  run python3 "$SCRIPT" guard --harness omp --tool write \
+    --path "$HOME/.claude/commands/git/commit.md" --content "x"
+
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s' "$output" | jq -r '.decision')" = "allow" ]
+}
+
+@test "agent-harnesses: guard denies writes to the control plane" {
+  for target in \
+    ".agents/harness/hooks/safety.py" \
+    "scripts/agent-harnesses.py" \
+    ".agents/harness/self-improve-policy.json"; do
+    run python3 "$SCRIPT" guard --harness omp --tool write \
+      --path "$HOME/$target" --content "x"
+
+    [ "$status" -eq 2 ]
+    [ "$(printf '%s' "$output" | jq -r '.decision')" = "deny" ]
+  done
+}
+
+@test "agent-harnesses: provenance classifies generated, source, and generator paths" {
+  run python3 "$SCRIPT" provenance --json --path "$HOME/.pi/agent/agents.json"
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s' "$output" | jq -r '.kind')" = "generated" ]
+
+  run python3 "$SCRIPT" provenance --json --path "$HOME/.claude/commands/git/commit.md"
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s' "$output" | jq -r '.kind')" = "source" ]
+
+  run python3 "$SCRIPT" provenance --json --path "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s' "$output" | jq -r '.kind')" = "generator" ]
+}


### PR DESCRIPTION
## Summary

The plan was to build a loop that watches how the agent harness falls short, proposes work, and — once approved — opens pull requests with the changes. Designing it surfaced three problems that mean it cannot be built safely yet, so this pull request fixes those instead and leaves the loop unbuilt.

The short version: the review step everything depends on was not actually enforced, the safety guard did not protect itself, and files that get regenerated automatically could be edited without warning. All three were already true before any of this work started.

## Changes

**The guard now protects itself.** The protected-path list covered credentials only, so an agent could edit the very file that decides what agents may edit. The policy module, the generator, the per-harness guard shims, and the autonomy policy are now human-only. Kept narrow on purpose — blanket entries like `.gitignore` would tax every session in every repository.

**Generated files are recognizable.** Editing one silently lost the work at the next `just harness-generate`. Grepping for the managed header could not catch it: the header is a comment, so the four generated JSON artifacts carried no marker at all. The generator now emits `generated-paths.json`, mapping all 274 artifacts to the source behind them, and the guard reads it and names the file to edit instead. Provenance is derived from `render_all()` rather than restated, so a new adapter cannot be added without it.

- Adds a `provenance` subcommand reporting generated / source / generator / other for a path.
- Both it and `guard` avoid `tomllib`, which needs Python 3.11+ — the interpreter on `PATH` under launchd is the system 3.9.

**Required checks can now be turned on.** `lint`, `test`, and `harness-parity` filtered at the `on:` trigger, so a pull request touching none of their paths produced no check run. Making them required in that state would have left every unrelated pull request stuck on "Expected" forever. Filtering moved into the jobs; the workflows always report. While moving it, the parity filter gained `.agents/skills/**`, a generator input that previously produced no signal.

**A human-approval gate.** A review count cannot work on a solo repository — GitHub disables self-approval. Instead, agent-authored work carries a `agent-authored` label and the check fails until a human adds `human-approved`. Hand-written pull requests pass straight through.

**A spec format, and the first spec.** `docs/specs/001` records the reasoning above in the format future work should use. A spec here is a rejection interface: it exists so work can be killed in thirty seconds of reading.

**An unrelated but blocking bug fix.** `.claude/hooks/scripts/pre-commit-format.sh` opened with `declare -A`, which needs bash 4; macOS ships 3.2 and the hook is invoked as `bash <script>`. It failed closed on line 8, so no commit issued through Claude Code could run at all, and `just format` never ran pre-commit. Found because it blocked this branch.

## Follow-up required after merge — do not skip

The ruleset changes are deliberately **not** in this pull request, because applying them before these workflows are on `main` would deadlock every pull request on checks that do not exist yet.

Once merged, apply by hand:

1. **Empty `bypass_actors` on ruleset 13542903** (`Protect main`). It currently holds `{actor_id: 5, actor_type: RepositoryRole, bypass_mode: always}` — repository admins bypass the rule always. Until this is emptied, every other protection here is decorative, because any agent runs with an admin token.
2. **Add a `required_status_checks` rule** pinning `lint`, `test`, `harness-parity`, and `human-approval`. There is no such rule today, so CI passing is not currently a merge condition.
3. Consider flipping `review_draft_pull_requests` to `true` on ruleset 13416093, so Copilot reviews draft pull requests — the ones an agent would open.

The `agent-authored` and `human-approved` labels are created as part of this work; the gate cannot be applied to a pull request without them.

Round-trip the existing ruleset JSON rather than hand-authoring it; `PUT` replaces the whole object.

## Verification

`HOME=$PWD` throughout, because the generator writes to `$HOME` and this is a worktree.

- All 33 tests in `tests/agent-harnesses.bats` pass, including 5 new ones covering the manifest, the guard denials, and `provenance`.
- Local runs under the system Python 3.9 show 9 pre-existing failures unrelated to this change; they fail identically on an unmodified checkout of `main` and all pass under Python 3.14. CI uses a modern interpreter.
- `just harness-check` (parity) passes; `ruff` and `shellcheck` clean; `yamllint` clean on all three workflows.

## Note for the reviewer

Running the test suite locally with `HOME` remapped to a worktree truncated `.claude/settings.json` from 271 lines to 9. Reverted, and not part of this diff, but it is a live data-loss risk worth a separate look.
