### PR TITLE
feat(ci): add agentic-review PR review workflow

### DIFF
--- a/.github/agentic-review/config.yaml
+++ b/.github/agentic-review/config.yaml
@@ -1,0 +1,35 @@
+# agentic-review deployment config for phatblat/dotfiles.
+#
+# endpoint is blank on purpose: the workflow's `endpoint` input fills any
+# blank binding at runtime (vars.AGENTIC_REVIEW_ENDPOINT). A non-blank
+# value here would always win over that input.
+#
+# reasoning_effort: none is load-bearing, not a preference. This model
+# reasons by default and bills reasoning tokens as completion tokens, so a
+# persona budget sized for its answer gets spent thinking before the answer
+# starts (docs/setup.md:47-82).
+version: 1
+
+models:
+  triage:
+    endpoint: ""
+    model: Inferact/Qwen3.8-27B-NVFP4
+    context_window: 131072
+    reasoning_effort: none
+  review:
+    endpoint: ""
+    model: Inferact/Qwen3.8-27B-NVFP4
+    context_window: 131072
+    reasoning_effort: none
+  verify:
+    endpoint: ""
+    model: Inferact/Qwen3.8-27B-NVFP4
+    context_window: 131072
+    reasoning_effort: none
+
+review:
+  gate:
+    # Advisory check, so red must mean something. Every dotfiles daily PR
+    # carries agent-config churn that classifies as `source`, and the
+    # default fail_on: nit would put a red X on essentially all of them.
+    fail_on: blocker

--- a/.github/workflows/agentic-review.yml
+++ b/.github/workflows/agentic-review.yml
@@ -1,0 +1,109 @@
+name: agentic-review
+
+# synchronize is deliberately not a trigger: v1 never re-reviews on push
+# (docs/setup.md:282-285). Use /agentic-review in a PR comment instead.
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened, edited]
+    branches: [main]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    if: github.event_name == 'pull_request'
+    runs-on: [self-hosted, spark]
+    timeout-minutes: 30
+    steps:
+      # Config loads from the PR head, not the merge commit (spec §12.4).
+      # Sparse: only .github/agentic-review/** is read from disk; every
+      # file body comes from the GitHub API.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          sparse-checkout: .github/agentic-review
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: phatblat/agentic-review
+          ref: 2f2772e7ea7f61da4a4e1642456015754bb1e178
+          path: agentic-review
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: agentic-review/go.mod
+
+      # The shim version-checks $AGENTIC_REVIEW_BIN against its own
+      # EXPECTED_VERSION, so stamp the value read out of the checked-out
+      # shim rather than duplicating it here.
+      - name: Build agentic-review
+        working-directory: agentic-review
+        run: |
+          version=$(sed -n 's/^export const EXPECTED_VERSION = "\(.*\)";$/\1/p' shim/index.mjs)
+          go build -ldflags "-X main.version=${version}" \
+            -o "${RUNNER_TEMP}/agentic-review-bin" ./cmd/agentic-review
+
+      - uses: ./agentic-review
+        env:
+          AGENTIC_REVIEW_BIN: ${{ runner.temp }}/agentic-review-bin
+        with:
+          endpoint: ${{ vars.AGENTIC_REVIEW_ENDPOINT }}
+          api_key: ${{ secrets.AGENTIC_REVIEW_API_KEY }}
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: agentic-review-run
+          path: ${{ runner.temp }}/agentic-review/
+          if-no-files-found: ignore
+
+  summons:
+    # Job-level guard: evaluated before runner assignment, so no-op
+    # comments never occupy the runner (spec §11.2).
+    if: >
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/agentic-review') &&
+      github.event.comment.user.type != 'Bot'
+    runs-on: [self-hosted, spark]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
+          sparse-checkout: .github/agentic-review
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: phatblat/agentic-review
+          ref: 2f2772e7ea7f61da4a4e1642456015754bb1e178
+          path: agentic-review
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: agentic-review/go.mod
+
+      - name: Build agentic-review
+        working-directory: agentic-review
+        run: |
+          version=$(sed -n 's/^export const EXPECTED_VERSION = "\(.*\)";$/\1/p' shim/index.mjs)
+          go build -ldflags "-X main.version=${version}" \
+            -o "${RUNNER_TEMP}/agentic-review-bin" ./cmd/agentic-review
+
+      - uses: ./agentic-review
+        env:
+          AGENTIC_REVIEW_BIN: ${{ runner.temp }}/agentic-review-bin
+        with:
+          endpoint: ${{ vars.AGENTIC_REVIEW_ENDPOINT }}
+          api_key: ${{ secrets.AGENTIC_REVIEW_API_KEY }}
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: agentic-review-run
+          path: ${{ runner.temp }}/agentic-review/
+          if-no-files-found: ignore


### PR DESCRIPTION
Bootstraps the `agentic-review` GitHub Action for this repo: builds `phatblat/agentic-review` from source and runs it on a self-hosted `spark` runner (spark1, ephemeral container) against the local vLLM endpoint.

This PR is expected to exit 2 from `config-guard` (blocker on `gate.fail_on weakened from nit to blocker` and on the new workflow's `permissions:` block) — that's a one-time signal from adding review-config for the first time, not a real problem. Merge despite the red X; the branch ruleset's required checks are `lint`, `GitGuardian Security Checks`, `human-approval`, `test`.

Prereqs already in place: `AGENTIC_REVIEW_ENDPOINT` var and `AGENTIC_REVIEW_API_KEY` secret set; fork-PR approval tightened to `all_external_contributors`.

Co-Authored-By: oh-my-pi <omp@can.ac>